### PR TITLE
Fix MPQ detection failing when files are lowercase .mpq

### DIFF
--- a/extract_assets.sh
+++ b/extract_assets.sh
@@ -54,7 +54,7 @@ if [ -d "${OUTPUT_DIR}/expansions" ]; then
 fi
 
 # Quick sanity check: look for any .MPQ files
-if ! ls "$MPQ_DIR"/*.MPQ "$MPQ_DIR"/*.mpq 2>/dev/null | head -1 > /dev/null 2>&1; then
+if ! compgen -G "$MPQ_DIR"/*.MPQ > /dev/null 2>&1 && ! compgen -G "$MPQ_DIR"/*.mpq > /dev/null 2>&1; then
     echo "Error: No .MPQ files found in: $MPQ_DIR"
     echo "Make sure this is the WoW Data/ directory (not the WoW root)."
     exit 1


### PR DESCRIPTION
## Summary

- **Fix**: `extract_assets.sh` fails with "No .MPQ files found" even when valid `.mpq` files exist in the target directory.

## Problem

The sanity check on [line 57](https://github.com/Kelsidavis/WoWee/blob/main/extract_assets.sh#L57) uses:

```bash
ls "$MPQ_DIR"/*.MPQ "$MPQ_DIR"/*.mpq 2>/dev/null | head -1 > /dev/null 2>&1
```

Retail WoW 3.3.5a installations (e.g. installed from DVD) use lowercase `.mpq` extensions. When no uppercase `.MPQ` files exist, `ls` exits non-zero because the `*.MPQ` glob is passed as a literal string that doesn't match any file. Since the script uses `set -o pipefail`, that non-zero exit propagates through the pipeline, causing the entire check to fail — even though the `.mpq` files were found successfully.

## Fix

Replace the single `ls | head` pipeline with two independent `compgen -G` checks:

```bash
if ! compgen -G "$MPQ_DIR"/*.MPQ > /dev/null 2>&1 && ! compgen -G "$MPQ_DIR"/*.mpq > /dev/null 2>&1; then
```

`compgen -G` tests whether a glob matches any files without spawning `ls`, avoids the pipefail issue entirely, and correctly passes when either case variant exists.

## Test plan

- [x] Tested with a retail 3.3.5a install containing only lowercase `.mpq` files — extraction now proceeds correctly
- [X] Verify still works with uppercase `.MPQ` files
- [X] Verify still catches directories with no MPQ files at all