### PR TITLE
fix(arch): add vulkan-headers to Arch Linux dependency list

### DIFF
--- a/BUILD_INSTRUCTIONS.md
+++ b/BUILD_INSTRUCTIONS.md
@@ -29,9 +29,13 @@ sudo apt install -y \
 sudo pacman -S --needed \
   base-devel cmake pkgconf git \
   sdl2 glew glm openssl zlib \
-  vulkan-devel vulkan-tools shaderc \
+  vulkan-headers vulkan-icd-loader vulkan-tools shaderc \
   ffmpeg unicorn stormlib
 ```
+
+> **Note:** `vulkan-headers` provides the `vulkan/vulkan.h` development headers required
+> at build time. `vulkan-devel` is a group that includes these on some distros but is not
+> available by name on Arch — install `vulkan-headers` and `vulkan-icd-loader` explicitly.
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces the non-existent `vulkan-devel` group with the correct individual packages: `vulkan-headers` and `vulkan-icd-loader`
- Adds an explanatory note so future readers understand why the split is needed on Arch

## Problem

On Arch Linux (and derivatives like CachyOS, Manjaro), `vulkan-devel` is **not a valid package name**. The Vulkan development headers (`vulkan/vulkan.h`) are provided by the separate `vulkan-headers` package. Without it, the build fails immediately:

```
fatal error: vulkan/vulkan.h: No such file or directory
```

This affects both `imgui` (imgui_impl_vulkan.cpp) and `vk-bootstrap` — the two submodule dependencies.

## Test plan

- [ ] Fresh Arch/CachyOS install: run the updated `pacman -S` command and confirm `cmake` + `make` succeed without the Vulkan header error