### PR TITLE
fix: revert WotLK CharSections.dbc field indices corrupted by e9ce0621

### DIFF
--- a/Data/expansions/wotlk/dbc_layouts.json
+++ b/Data/expansions/wotlk/dbc_layouts.json
@@ -25,14 +25,14 @@
   },
   "CharSections": {
     "BaseSection": 3,
-    "ColorIndex": 5,
-    "Flags": 9,
+    "ColorIndex": 9,
+    "Flags": 7,
     "RaceID": 1,
     "SexID": 2,
-    "Texture1": 6,
-    "Texture2": 7,
-    "Texture3": 8,
-    "VariationIndex": 4
+    "Texture1": 4,
+    "Texture2": 5,
+    "Texture3": 6,
+    "VariationIndex": 8
   },
   "CharTitles": {
     "ID": 0,


### PR DESCRIPTION
## Problem

Commit e9ce0621 ("restore correct CharSections.dbc field indices") correctly fixed Classic, TBC, and Turtle — but incorrectly applied the same field reordering to WotLK. WotLK's `CharSections.dbc` uses a **different field layout** than the other expansions, so the "fix" left WotLK with the wrong indices, producing white/untextured character models at the login screen and character creation screen.

## Root Cause

`e9ce0621` asserted that all four expansions share the same DBC layout (Classic, TBC, Turtle — all identical). This is true for those three, but not for WotLK. Binary inspection of CharSections.dbc (WotLK, 8958 records, 10 fields) shows:

```
Field 4 → string offset → resolves to e.g. "Character\Human\Male\HumanMaleSkin00_00.blp"
Field 5 → string offset (Texture2)
Field 6 → string offset (Texture3)
Field 7 → integer (Flags, value 17 = 0x11)
Field 8 → integer (VariationIndex, value 0)
Field 9 → integer (ColorIndex, value 0, 1, 2 … matching skin index)
```

With `e9ce0621`'s indices applied to WotLK, field 4 (a string offset like `397`) was being read as `VariationIndex`. That never matched the expected `0`/`1`/`2` values, so every `CharSections` row was skipped and no textures were loaded.

## Fix

Revert dbc_layouts.json `CharSections` to the original WotLK-correct layout:

| Field | Key |
|-------|-----|
| 4 | `Texture1` |
| 5 | `Texture2` |
| 6 | `Texture3` |
| 7 | `Flags` |
| 8 | `VariationIndex` |
| 9 | `ColorIndex` |

No changes to `character_preview.cpp`, `character_create_screen.cpp`, or `application.cpp` — all three already read field indices from the JSON layout at runtime via `csL`, so fixing the JSON is sufficient.

## Testing

- client WotLK from ChromieCraft (if it necessary) was the source of assets
- WotLK character preview at login screen: textures load correctly (no white models)
- WotLK character creation screen: skin/face/hair variation ranges resolve correctly
- Classic, TBC, Turtle layouts: unchanged, unaffected