### PR TITLE
[chore] refactor: Break Application::getInstance() from GameHandler

### DIFF
--- a/include/core/application.hpp
+++ b/include/core/application.hpp
@@ -3,6 +3,7 @@
 #include "core/window.hpp"
 #include "core/input.hpp"
 #include "game/character.hpp"
+#include "game/game_services.hpp"
 #include "pipeline/blp_loader.hpp"
 #include <memory>
 #include <string>
@@ -126,6 +127,7 @@ private:
 
     static Application* instance;
 
+    game::GameServices gameServices_;
     std::unique_ptr<Window> window;
     std::unique_ptr<rendering::Renderer> renderer;
     std::unique_ptr<ui::UIManager> uiManager;

--- a/include/game/game_handler.hpp
+++ b/include/game/game_handler.hpp
@@ -13,6 +13,7 @@
 #include "game/quest_handler.hpp"
 #include "game/movement_handler.hpp"
 #include "game/entity_controller.hpp"
+#include "game/game_services.hpp"
 #include "network/packet.hpp"
 #include <glm/glm.hpp>
 #include <memory>
@@ -130,8 +131,10 @@ public:
     using TalentEntry = game::TalentEntry;
     using TalentTabEntry = game::TalentTabEntry;
 
-    GameHandler();
+    explicit GameHandler(GameServices& services);
     ~GameHandler();
+
+    const GameServices& services() const { return services_; }
 
     /** Access the active opcode table (wire ↔ logical mapping). */
     const OpcodeTable& getOpcodeTable() const { return opcodeTable_; }
@@ -2297,6 +2300,9 @@ private:
                                 const glm::vec3& localOffset, bool hasLocalOrientation,
                                 float localOrientation);
     void clearTransportAttachment(uint64_t childGuid);
+
+    // Explicit service dependencies (owned by Application)
+    GameServices& services_;
 
     // Domain handlers — each manages a specific concern extracted from GameHandler
     std::unique_ptr<ChatHandler>      chatHandler_;

--- a/include/game/game_services.hpp
+++ b/include/game/game_services.hpp
@@ -1,0 +1,23 @@
+#pragma once
+#include <cstdint>
+
+namespace wowee {
+namespace rendering { class Renderer; }
+namespace pipeline { class AssetManager; }
+namespace game { class ExpansionRegistry; }
+
+namespace game {
+
+// Explicit service dependencies for game handlers.
+// Owned by Application, passed by reference to GameHandler at construction.
+// Replaces hidden Application::getInstance() singleton access.
+struct GameServices {
+    rendering::Renderer* renderer = nullptr;
+    pipeline::AssetManager* assetManager = nullptr;
+    game::ExpansionRegistry* expansionRegistry = nullptr;
+    uint32_t gryphonDisplayId = 0;
+    uint32_t wyvernDisplayId = 0;
+};
+
+} // namespace game
+} // namespace wowee

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -256,7 +256,6 @@ bool Application::initialize() {
 
     // Create subsystems
     authHandler = std::make_unique<auth::AuthHandler>();
-    gameHandler = std::make_unique<game::GameHandler>();
     world = std::make_unique<game::World>();
 
     // Create and initialize expansion registry
@@ -267,6 +266,14 @@ bool Application::initialize() {
 
     // Create asset manager
     assetManager = std::make_unique<pipeline::AssetManager>();
+
+    // Populate game services — all subsystems now available
+    gameServices_.renderer = renderer.get();
+    gameServices_.assetManager = assetManager.get();
+    gameServices_.expansionRegistry = expansionRegistry_.get();
+
+    // Create game handler with explicit service dependencies
+    gameHandler = std::make_unique<game::GameHandler>(gameServices_);
 
     // Try to get WoW data path from environment variable
     const char* dataPathEnv = std::getenv("WOW_DATA_PATH");
@@ -5657,6 +5664,8 @@ void Application::buildCreatureDisplayLookups() {
 
     gryphonDisplayId_ = resolveDisplayIdForExactPath("Creature\\Gryphon\\Gryphon.m2");
     wyvernDisplayId_  = resolveDisplayIdForExactPath("Creature\\Wyvern\\Wyvern.m2");
+    gameServices_.gryphonDisplayId = gryphonDisplayId_;
+    gameServices_.wyvernDisplayId  = wyvernDisplayId_;
     LOG_INFO("Taxi mount displayIds: gryphon=", gryphonDisplayId_, " wyvern=", wyvernDisplayId_);
 
     // CharHairGeosets.dbc: maps (race, sex, hairStyleId) → skinSectionId for hair mesh

--- a/src/game/combat_handler.cpp
+++ b/src/game/combat_handler.cpp
@@ -451,7 +451,7 @@ void CombatHandler::handleAttackerStateUpdate(network::Packet& packet) {
     }
 
     // Play combat sounds via CombatSoundManager + character vocalizations
-    if (auto* renderer = core::Application::getInstance().getRenderer()) {
+    if (auto* renderer = owner_.services().renderer) {
         if (auto* csm = renderer->getCombatSoundManager()) {
             auto weaponSize = audio::CombatSoundManager::WeaponSize::MEDIUM;
             if (data.isMiss()) {

--- a/src/game/game_handler.cpp
+++ b/src/game/game_handler.cpp
@@ -1,4 +1,5 @@
 #include "game/game_handler.hpp"
+#include "game/game_utils.hpp"
 #include "game/chat_handler.hpp"
 #include "game/movement_handler.hpp"
 #include "game/combat_handler.hpp"
@@ -91,23 +92,6 @@ bool isAuthCharPipelineOpcode(LogicalOpcode op) {
 } // end anonymous namespace
 
 namespace {
-
-bool isActiveExpansion(const char* expansionId) {
-    auto& app = core::Application::getInstance();
-    auto* registry = app.getExpansionRegistry();
-    if (!registry) return false;
-    auto* profile = registry->getActive();
-    if (!profile) return false;
-    return profile->id == expansionId;
-}
-
-bool isClassicLikeExpansion() {
-    return isActiveExpansion("classic") || isActiveExpansion("turtle");
-}
-
-bool isPreWotlk() {
-    return isClassicLikeExpansion() || isActiveExpansion("tbc");
-}
 
 bool envFlagEnabled(const char* key, bool defaultValue = false) {
     const char* raw = std::getenv(key);
@@ -615,7 +599,7 @@ static QuestQueryRewards tryParseQuestRewards(const std::vector<uint8_t>& data,
 
 template<typename ManagerGetter, typename Callback>
 void GameHandler::withSoundManager(ManagerGetter getter, Callback cb) {
-    if (auto* renderer = core::Application::getInstance().getRenderer()) {
+    if (auto* renderer = services_.renderer) {
         if (auto* mgr = (renderer->*getter)()) cb(mgr);
     }
 }
@@ -639,7 +623,8 @@ void GameHandler::registerWorldHandler(LogicalOpcode op, void (GameHandler::*han
     };
 }
 
-GameHandler::GameHandler() {
+GameHandler::GameHandler(GameServices& services)
+    : services_(services) {
     LOG_DEBUG("GameHandler created");
 
     setActiveOpcodeTable(&opcodeTable_);
@@ -819,7 +804,7 @@ void GameHandler::resetDbcCaches() {
     // Clear the AssetManager DBC file cache so that expansion-specific DBCs
     // (CharSections, ItemDisplayInfo, etc.) are reloaded from the new expansion's
     // MPQ files instead of returning stale data from a previous session/expansion.
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = services_.assetManager;
     if (am) {
         am->clearDBCCache();
     }
@@ -1213,7 +1198,7 @@ void GameHandler::updateTimers(float deltaTime) {
             }
             if (!alreadyAnnounced && pendingLootMoneyAmount_ > 0) {
                 addSystemChatMessage("Looted: " + formatCopperAmount(pendingLootMoneyAmount_));
-                auto* renderer = core::Application::getInstance().getRenderer();
+                auto* renderer = services_.renderer;
                 if (renderer) {
                     if (auto* sfx = renderer->getUiSoundManager()) {
                         if (pendingLootMoneyAmount_ >= 10000) {
@@ -3099,7 +3084,7 @@ void GameHandler::registerOpcodeHandlers() {
         uint64_t impTargetGuid = packet.readUInt64();
         uint32_t impVisualId   = packet.readUInt32();
         if (impVisualId == 0) return;
-        auto* renderer = core::Application::getInstance().getRenderer();
+        auto* renderer = services_.renderer;
         if (!renderer) return;
         glm::vec3 spawnPos;
         if (impTargetGuid == playerGuid) {
@@ -7249,7 +7234,7 @@ void GameHandler::loadTitleNameCache() const {
     if (titleNameCacheLoaded_) return;
     titleNameCacheLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = services_.assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("CharTitles.dbc");
@@ -7301,7 +7286,7 @@ void GameHandler::loadAchievementNameCache() {
     if (achievementNameCacheLoaded_) return;
     achievementNameCacheLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = services_.assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("Achievement.dbc");
@@ -7386,7 +7371,7 @@ void GameHandler::loadFactionNameCache() const {
     if (factionNameCacheLoaded_) return;
     factionNameCacheLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = services_.assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("Faction.dbc");
@@ -7487,7 +7472,7 @@ void GameHandler::loadAreaNameCache() const {
     if (areaNameCacheLoaded_) return;
     areaNameCacheLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = services_.assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("WorldMapArea.dbc");
@@ -7522,7 +7507,7 @@ void GameHandler::loadMapNameCache() const {
     if (mapNameCacheLoaded_) return;
     mapNameCacheLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = services_.assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("Map.dbc");
@@ -7555,7 +7540,7 @@ void GameHandler::loadLfgDungeonDbc() const {
     if (lfgDungeonNameCacheLoaded_) return;
     lfgDungeonNameCacheLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = services_.assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("LFGDungeons.dbc");

--- a/src/game/inventory_handler.cpp
+++ b/src/game/inventory_handler.cpp
@@ -70,7 +70,7 @@ void InventoryHandler::registerOpcodes(DispatchTable& table) {
         }
         if (!alreadyAnnounced) {
             owner_.addSystemChatMessage("Looted: " + formatCopperAmount(amount));
-            auto* renderer = core::Application::getInstance().getRenderer();
+            auto* renderer = owner_.services().renderer;
             if (renderer) {
                 if (auto* sfx = renderer->getUiSoundManager()) {
                     if (amount >= 10000) sfx->playLootCoinLarge();
@@ -222,7 +222,7 @@ void InventoryHandler::registerOpcodes(DispatchTable& table) {
         std::string msg = "Received item: " + link;
         if (count > 1) msg += " x" + std::to_string(count);
         owner_.addSystemChatMessage(msg);
-        if (auto* renderer = core::Application::getInstance().getRenderer()) {
+        if (auto* renderer = owner_.services().renderer) {
             if (auto* sfx = renderer->getUiSoundManager())
                 sfx->playLootItem();
         }
@@ -253,7 +253,7 @@ void InventoryHandler::registerOpcodes(DispatchTable& table) {
                      " result=", static_cast<int>(result));
             if (result == 0) {
                 pendingSellToBuyback_.erase(itemGuid);
-                if (auto* renderer = core::Application::getInstance().getRenderer()) {
+                if (auto* renderer = owner_.services().renderer) {
                     if (auto* sfx = renderer->getUiSoundManager())
                         sfx->playDropOnGround();
                 }
@@ -295,7 +295,7 @@ void InventoryHandler::registerOpcodes(DispatchTable& table) {
                 const char* msg = (result < 7) ? sellErrors[result] : "Unknown sell error";
                 owner_.addUIError(std::string("Sell failed: ") + msg);
                 owner_.addSystemChatMessage(std::string("Sell failed: ") + msg);
-                if (auto* renderer = core::Application::getInstance().getRenderer()) {
+                if (auto* renderer = owner_.services().renderer) {
                     if (auto* sfx = renderer->getUiSoundManager())
                         sfx->playError();
                 }
@@ -392,7 +392,7 @@ void InventoryHandler::registerOpcodes(DispatchTable& table) {
                 std::string msg = errMsg ? errMsg : "Inventory error (" + std::to_string(error) + ").";
                 owner_.addUIError(msg);
                 owner_.addSystemChatMessage(msg);
-                if (auto* renderer = core::Application::getInstance().getRenderer()) {
+                if (auto* renderer = owner_.services().renderer) {
                     if (auto* sfx = renderer->getUiSoundManager())
                         sfx->playError();
                 }
@@ -450,7 +450,7 @@ void InventoryHandler::registerOpcodes(DispatchTable& table) {
             }
             owner_.addUIError(msg);
             owner_.addSystemChatMessage(msg);
-            if (auto* renderer = core::Application::getInstance().getRenderer()) {
+            if (auto* renderer = owner_.services().renderer) {
                 if (auto* sfx = renderer->getUiSoundManager())
                     sfx->playError();
             }
@@ -474,7 +474,7 @@ void InventoryHandler::registerOpcodes(DispatchTable& table) {
                 std::string msg = "Purchased: " + buildItemLink(pendingBuyItemId_, buyQuality, itemLabel);
                 if (itemCount > 1) msg += " x" + std::to_string(itemCount);
                 owner_.addSystemChatMessage(msg);
-                if (auto* renderer = core::Application::getInstance().getRenderer()) {
+                if (auto* renderer = owner_.services().renderer) {
                     if (auto* sfx = renderer->getUiSoundManager())
                         sfx->playPickupBag();
                 }
@@ -763,7 +763,7 @@ void InventoryHandler::handleLootRemoved(network::Packet& packet) {
             std::string msgStr = "Looted: " + link;
             if (it->count > 1) msgStr += " x" + std::to_string(it->count);
             owner_.addSystemChatMessage(msgStr);
-            if (auto* renderer = core::Application::getInstance().getRenderer()) {
+            if (auto* renderer = owner_.services().renderer) {
                 if (auto* sfx = renderer->getUiSoundManager())
                     sfx->playLootItem();
             }
@@ -2377,7 +2377,7 @@ void InventoryHandler::handleItemQueryResponse(network::Packet& packet) {
                 std::string msg = "Received: " + link;
                 if (it->count > 1) msg += " x" + std::to_string(it->count);
                 owner_.addSystemChatMessage(msg);
-                if (auto* renderer = core::Application::getInstance().getRenderer()) {
+                if (auto* renderer = owner_.services().renderer) {
                     if (auto* sfx = renderer->getUiSoundManager()) sfx->playLootItem();
                 }
                 if (owner_.itemLootCallback_) owner_.itemLootCallback_(data.entry, it->count, data.quality, itemName);
@@ -3144,7 +3144,7 @@ void InventoryHandler::handleTrainerBuySucceeded(network::Packet& packet) {
         owner_.addSystemChatMessage("You have learned " + name + ".");
     else
         owner_.addSystemChatMessage("Spell learned.");
-    if (auto* renderer = core::Application::getInstance().getRenderer())
+    if (auto* renderer = owner_.services().renderer)
         if (auto* sfx = renderer->getUiSoundManager()) sfx->playQuestActivate();
     owner_.fireAddonEvent("TRAINER_UPDATE", {});
     owner_.fireAddonEvent("SPELLS_CHANGED", {});
@@ -3166,7 +3166,7 @@ void InventoryHandler::handleTrainerBuyFailed(network::Packet& packet) {
     else if (errorCode != 0) msg += " (error " + std::to_string(errorCode) + ")";
     owner_.addUIError(msg);
     owner_.addSystemChatMessage(msg);
-    if (auto* renderer = core::Application::getInstance().getRenderer())
+    if (auto* renderer = owner_.services().renderer)
         if (auto* sfx = renderer->getUiSoundManager()) sfx->playError();
 }
 

--- a/src/game/movement_handler.cpp
+++ b/src/game/movement_handler.cpp
@@ -1816,7 +1816,7 @@ void MovementHandler::loadTaxiDbc() {
     if (taxiDbcLoaded_) return;
     taxiDbcLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = owner_.services().assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto nodesDbc = am->loadDBC("TaxiNodes.dbc");
@@ -2005,9 +2005,8 @@ void MovementHandler::applyTaxiMountForCurrentNode() {
         if (mountId == 541) mountId = 0;
     }
     if (mountId == 0) {
-        auto& app = core::Application::getInstance();
-        uint32_t gryphonId = app.getGryphonDisplayId();
-        uint32_t wyvernId = app.getWyvernDisplayId();
+        uint32_t gryphonId = owner_.services().gryphonDisplayId;
+        uint32_t wyvernId = owner_.services().wyvernDisplayId;
         if (isAlliance && gryphonId != 0) mountId = gryphonId;
         if (!isAlliance && wyvernId != 0) mountId = wyvernId;
         if (mountId == 0) {
@@ -2496,7 +2495,7 @@ void MovementHandler::loadAreaTriggerDbc() {
     if (owner_.areaTriggerDbcLoaded_) return;
     owner_.areaTriggerDbcLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = owner_.services().assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("AreaTrigger.dbc");

--- a/src/game/quest_handler.cpp
+++ b/src/game/quest_handler.cpp
@@ -469,7 +469,7 @@ void QuestHandler::registerOpcodes(DispatchTable& table) {
                         owner_.questCompleteCallback_(questId, it->title);
                     }
                     // Play quest-complete sound
-                    if (auto* renderer = core::Application::getInstance().getRenderer()) {
+                    if (auto* renderer = owner_.services().renderer) {
                         if (auto* sfx = renderer->getUiSoundManager())
                             sfx->playQuestComplete();
                     }
@@ -1092,7 +1092,7 @@ void QuestHandler::acceptQuest() {
     pendingQuestAcceptNpcGuids_[questId] = npcGuid;
 
     // Play quest-accept sound
-    if (auto* renderer = core::Application::getInstance().getRenderer()) {
+    if (auto* renderer = owner_.services().renderer) {
         if (auto* sfx = renderer->getUiSoundManager())
             sfx->playQuestActivate();
     }

--- a/src/game/social_handler.cpp
+++ b/src/game/social_handler.cpp
@@ -1049,7 +1049,7 @@ void SocialHandler::handleDuelRequested(network::Packet& packet) {
     }
     pendingDuelRequest_ = true;
     owner_.addSystemChatMessage(duelChallengerName_ + " challenges you to a duel!");
-    if (auto* renderer = core::Application::getInstance().getRenderer())
+    if (auto* renderer = owner_.services().renderer)
         if (auto* sfx = renderer->getUiSoundManager()) sfx->playTargetSelect();
     if (owner_.addonEventCallback_) owner_.addonEventCallback_("DUEL_REQUESTED", {duelChallengerName_});
 }
@@ -1215,7 +1215,7 @@ void SocialHandler::handleGroupInvite(network::Packet& packet) {
     pendingInviterName = data.inviterName;
     if (!data.inviterName.empty())
         owner_.addSystemChatMessage(data.inviterName + " has invited you to a group.");
-    if (auto* renderer = core::Application::getInstance().getRenderer())
+    if (auto* renderer = owner_.services().renderer)
         if (auto* sfx = renderer->getUiSoundManager()) sfx->playTargetSelect();
     if (owner_.addonEventCallback_)
         owner_.addonEventCallback_("PARTY_INVITE_REQUEST", {data.inviterName});

--- a/src/game/spell_handler.cpp
+++ b/src/game/spell_handler.cpp
@@ -603,7 +603,7 @@ void SpellHandler::loadTalentDbc() {
     if (talentDbcLoaded_) return;
     talentDbcLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = owner_.services().assetManager;
     if (!am || !am->isInitialized()) return;
 
     // Load Talent.dbc
@@ -800,7 +800,7 @@ void SpellHandler::handleCastFailed(network::Packet& packet) {
     queuedSpellTarget_ = 0;
 
     // Stop precast sound
-    if (auto* renderer = core::Application::getInstance().getRenderer()) {
+    if (auto* renderer = owner_.services().renderer) {
         if (auto* ssm = renderer->getSpellSoundManager()) {
             ssm->stopPrecast();
         }
@@ -822,7 +822,7 @@ void SpellHandler::handleCastFailed(network::Packet& packet) {
     msg.message = errMsg;
     owner_.addLocalChatMessage(msg);
 
-    if (auto* renderer = core::Application::getInstance().getRenderer()) {
+    if (auto* renderer = owner_.services().renderer) {
         if (auto* sfx = renderer->getUiSoundManager())
             sfx->playError();
     }
@@ -874,7 +874,7 @@ void SpellHandler::handleSpellStart(network::Packet& packet) {
 
         // Play precast sound — skip profession/tradeskill spells
         if (!owner_.isProfessionSpell(data.spellId)) {
-            if (auto* renderer = core::Application::getInstance().getRenderer()) {
+            if (auto* renderer = owner_.services().renderer) {
                 if (auto* ssm = renderer->getSpellSoundManager()) {
                     owner_.loadSpellNameCache();
                     auto it = owner_.spellNameCache_.find(data.spellId);
@@ -912,7 +912,7 @@ void SpellHandler::handleSpellGo(network::Packet& packet) {
     if (data.casterUnit == owner_.playerGuid) {
         // Play cast-complete sound
         if (!owner_.isProfessionSpell(data.spellId)) {
-            if (auto* renderer = core::Application::getInstance().getRenderer()) {
+            if (auto* renderer = owner_.services().renderer) {
                 if (auto* ssm = renderer->getSpellSoundManager()) {
                     owner_.loadSpellNameCache();
                     auto it = owner_.spellNameCache_.find(data.spellId);
@@ -936,7 +936,7 @@ void SpellHandler::handleSpellGo(network::Packet& packet) {
         }
         if (isMeleeAbility) {
             if (owner_.meleeSwingCallback_) owner_.meleeSwingCallback_();
-            if (auto* renderer = core::Application::getInstance().getRenderer()) {
+            if (auto* renderer = owner_.services().renderer) {
                 if (auto* csm = renderer->getCombatSoundManager()) {
                     csm->playWeaponSwing(audio::CombatSoundManager::WeaponSize::MEDIUM, false);
                     csm->playImpact(audio::CombatSoundManager::WeaponSize::MEDIUM,
@@ -983,7 +983,7 @@ void SpellHandler::handleSpellGo(network::Packet& packet) {
             if (tgt == owner_.playerGuid) { targetsPlayer = true; break; }
         }
         if (targetsPlayer) {
-            if (auto* renderer = core::Application::getInstance().getRenderer()) {
+            if (auto* renderer = owner_.services().renderer) {
                 if (auto* ssm = renderer->getSpellSoundManager()) {
                     owner_.loadSpellNameCache();
                     auto it = owner_.spellNameCache_.find(data.spellId);
@@ -1029,7 +1029,7 @@ void SpellHandler::handleSpellGo(network::Packet& packet) {
     }
 
     if (playerIsHit || playerHitEnemy) {
-        if (auto* renderer = core::Application::getInstance().getRenderer()) {
+        if (auto* renderer = owner_.services().renderer) {
             if (auto* ssm = renderer->getSpellSoundManager()) {
                 owner_.loadSpellNameCache();
                 auto it = owner_.spellNameCache_.find(data.spellId);
@@ -1389,7 +1389,7 @@ void SpellHandler::handleAchievementEarned(network::Packet& packet) {
 
         owner_.earnedAchievements_.insert(achievementId);
         owner_.achievementDates_[achievementId] = earnDate;
-        if (auto* renderer = core::Application::getInstance().getRenderer()) {
+        if (auto* renderer = owner_.services().renderer) {
             if (auto* sfx = renderer->getUiSoundManager())
                 sfx->playAchievementAlert();
         }
@@ -1667,7 +1667,7 @@ void SpellHandler::loadSpellNameCache() const {
     if (owner_.spellNameCacheLoaded_) return;
     owner_.spellNameCacheLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = owner_.services().assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("Spell.dbc");
@@ -1779,7 +1779,7 @@ void SpellHandler::loadSkillLineAbilityDbc() {
     if (owner_.skillLineAbilityLoaded_) return;
     owner_.skillLineAbilityLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = owner_.services().assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto slaDbc = am->loadDBC("SkillLineAbility.dbc");
@@ -1880,7 +1880,7 @@ const std::string& SpellHandler::getSpellDescription(uint32_t spellId) const {
 
 std::string SpellHandler::getEnchantName(uint32_t enchantId) const {
     if (enchantId == 0) return {};
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = owner_.services().assetManager;
     if (!am || !am->isInitialized()) return {};
     auto dbc = am->loadDBC("SpellItemEnchantment.dbc");
     if (!dbc || !dbc->isLoaded()) return {};
@@ -1928,7 +1928,7 @@ void SpellHandler::loadSkillLineDbc() {
     if (owner_.skillLineDbcLoaded_) return;
     owner_.skillLineDbcLoaded_ = true;
 
-    auto* am = core::Application::getInstance().getAssetManager();
+    auto* am = owner_.services().assetManager;
     if (!am || !am->isInitialized()) return;
 
     auto dbc = am->loadDBC("SkillLine.dbc");
@@ -2141,7 +2141,7 @@ void SpellHandler::handlePlaySpellVisual(network::Packet& packet) {
     uint64_t casterGuid = packet.readUInt64();
     uint32_t visualId   = packet.readUInt32();
     if (visualId == 0) return;
-    auto* renderer = core::Application::getInstance().getRenderer();
+    auto* renderer = owner_.services().renderer;
     if (!renderer) return;
     glm::vec3 spawnPos;
     if (casterGuid == owner_.playerGuid) {
@@ -2339,7 +2339,7 @@ void SpellHandler::handleSpellFailure(network::Packet& packet) {
         craftQueueRemaining_ = 0;
         queuedSpellId_ = 0;
         queuedSpellTarget_ = 0;
-        if (auto* renderer = core::Application::getInstance().getRenderer()) {
+        if (auto* renderer = owner_.services().renderer) {
             if (auto* ssm = renderer->getSpellSoundManager()) {
                 ssm->stopPrecast();
             }

--- a/src/game/warden_handler.cpp
+++ b/src/game/warden_handler.cpp
@@ -781,7 +781,7 @@ void WardenHandler::handleWardenData(network::Packet& packet) {
                                         std::replace(np.begin(), np.end(), '/', '\\');
                                         auto knownIt = knownDoorHashes().find(np);
                                         if (knownIt != knownDoorHashes().end()) { found = true; hash.assign(knownIt->second.begin(), knownIt->second.end()); }
-                                        auto* am = core::Application::getInstance().getAssetManager();
+                                        auto* am = owner_.services().assetManager;
                                         if (am && am->isInitialized() && !found) {
                                             std::vector<uint8_t> fd;
                                             std::string rp = resolveCaseInsensitiveDataPath(am->getDataPath(), filePath);
@@ -1194,7 +1194,7 @@ void WardenHandler::handleWardenData(network::Packet& packet) {
                                 hash.assign(knownIt->second.begin(), knownIt->second.end());
                             }
 
-                            auto* am = core::Application::getInstance().getAssetManager();
+                            auto* am = owner_.services().assetManager;
                             if (am && am->isInitialized() && !found) {
                                 std::vector<uint8_t> fileData;
                                 std::string resolvedFsPath =


### PR DESCRIPTION
## Context — the refactoring project

> This PR is part of a long-running effort to tame four god classes that dominate the codebase. Here is the full picture so the change makes sense in isolation.

### The refactoring plan

**SOLID:** — turn a working codebase into one that stays working while becoming easier to extend, test, and reason about.

```
Tame GameHandler (27K lines)
  1.1  Table-driven dispatch          ✓ DONE
  1.2  Extract domain handlers        ✓ DONE
  1.3  Extract EntityController       ✓ DONE — previous PR
  1.4  Break Application::getInstance() cycle   ✓ DONE — this PR
```

---

## This PR — Break the Application singleton cycle

### The problem

After step 1.3, every domain handler (`InventoryHandler`, `SpellHandler`, `MovementHandler`, `CombatHandler`, `QuestHandler`, `SocialHandler`, `WardenHandler`) and `GameHandler` itself reached back into the global `Application` singleton to obtain the `Renderer`, `AssetManager`, `ExpansionRegistry`, and taxi-mount display IDs — **47 hidden `Application::getInstance()` calls** scattered across `src/game/*.cpp`.

This violated SOLID-D (dependency inversion): game-layer classes depended on the top-level application singleton rather than on abstractions. As a side-effect, `GameHandler` was being constructed **before** `AssetManager` and `ExpansionRegistry` existed, silently relying on deferred lazy access to avoid a crash.

---

## Solution — `GameServices` struct

A lightweight, aggregate struct owned by `Application`, populated after all subsystems are ready, and passed by reference to `GameHandler` at construction:

```cpp
// include/game/game_services.hpp
struct GameServices {
    rendering::Renderer*       renderer          = nullptr;
    pipeline::AssetManager*    assetManager      = nullptr;
    game::ExpansionRegistry*   expansionRegistry = nullptr;
    uint32_t gryphonDisplayId = 0;
    uint32_t wyvernDisplayId  = 0;
};
```

`GameHandler` receives it at construction and exposes a read-only accessor used by domain handlers:

```cpp
explicit GameHandler(GameServices& services);
const GameServices& services() const { return services_; }
```

Domain handlers access services through their existing `owner_` back-reference — no new constructor parameters, no new headers in handler TUs:

```cpp
// Before
auto* renderer = core::Application::getInstance().getRenderer();

// After
auto* renderer = owner_.services().renderer;
```

### Init-order fix (bonus correctness fix)

`GameHandler` creation was previously placed in `Application::initialize()` **before** `AssetManager` and `ExpansionRegistry` were constructed. `GameServices` made this explicit: the struct is only populated after all subsystems exist, and `GameHandler` is constructed immediately after. The latent risk of accessing a null subsystem pointer on startup is eliminated.

### Duplicate helper removal

`game_handler.cpp` contained an anonymous-namespace copy of `isActiveExpansion` / `isClassicLikeExpansion` / `isPreWotlk` that called `Application::getInstance()` internally. These were replaced by including `game_utils.hpp`, which provides the canonical definitions.

---

## Files changed

| File | Change |
|------|--------|
| `include/game/game_services.hpp` | **New** — `GameServices` struct |
| `include/game/game_handler.hpp` | Constructor signature + `services()` accessor + `services_` member |
| `include/core/application.hpp` | `game::GameServices gameServices_` member |
| `src/core/application.cpp` | Populate `gameServices_` after subsystem init; move `GameHandler` construction to after `AssetManager`; sync display IDs after DBC load |
| `src/game/game_handler.cpp` | Constructor change; remove duplicate helpers; `#include "game/game_utils.hpp"` |
| `src/game/inventory_handler.cpp` | 11 `getInstance()` calls → `owner_.services().renderer` |
| `src/game/spell_handler.cpp` | 15 calls → `owner_.services().renderer` / `.assetManager` |
| `src/game/movement_handler.cpp` | 3 calls → `.assetManager` / `.gryphonDisplayId` / `.wyvernDisplayId` |
| `src/game/combat_handler.cpp` | 1 call → `.renderer` |
| `src/game/quest_handler.cpp` | 2 calls → `.renderer` |
| `src/game/social_handler.cpp` | 2 calls → `.renderer` |
| `src/game/warden_handler.cpp` | 2 calls → `.assetManager` |

**Total:** 47 `Application::getInstance()` calls removed, 0 remaining in `src/game/`.

---

## Metrics

| Metric | Before | After | Δ |
|--------|:------:|:-----:|:-:|
| `Application::getInstance()` in `src/game/` | 47 | **0** | −47 |
| `GameHandler` constructor parameters | 0 | 1 (`GameServices&`) | explicit |
| Init-order hazard (GameHandler before AssetManager) | present | **fixed** | — |
| New files | — | 1 | — |

---

## Final thoughts

With step 1.4 complete, `GameHandler` no longer has any knowledge of `Application`. It can be constructed with any `GameServices` instance — including a test double. This is the prerequisite for unit-testing game logic without launching the full application stack.

**`GameHandler` line count through the series:**

| Step | Lines |
|------|------:|
| Start (1.0) | 26,160 |
| After 1.1 (table dispatch) | ~24,000 |
| After 1.2 (domain handlers) | 10,143 |
| After 1.3 (EntityController) | 8,095 |
| After 1.4 (this PR) | ~8,050 |