### PR TITLE
fix(tbc): support MaNGOS realm character enumeration

### DIFF
--- a/include/auth/auth_packets.hpp
+++ b/include/auth/auth_packets.hpp
@@ -130,7 +130,8 @@ struct RealmListResponse {
 // REALM_LIST response parser
 class RealmListResponseParser {
 public:
-    // protocolVersion: 3 = vanilla (uint8 realmCount, uint32 icon), 8 = WotLK (uint16 realmCount, uint8 icon)
+    // protocolVersion: 3 = legacy vanilla (uint8 realmCount, uint32 icon);
+    // TBC/WotLK use uint16 realmCount and byte-sized icon/lock/flags.
     [[nodiscard]] static bool parse(network::Packet& packet, RealmListResponse& response, uint8_t protocolVersion = 8);
 };
 

--- a/include/auth/vanilla_crypt.hpp
+++ b/include/auth/vanilla_crypt.hpp
@@ -9,9 +9,10 @@ namespace auth {
 /**
  * Vanilla/TBC WoW Header Cipher
  *
- * Used for encrypting/decrypting World of Warcraft packet headers
- * in vanilla (1.x) and TBC (2.x) clients. This is a simple XOR+addition
- * chaining cipher that uses the raw 40-byte SRP session key directly.
+ * Used for encrypting/decrypting World of Warcraft packet headers with the
+ * legacy XOR+addition chaining cipher. Vanilla/classic uses the raw 40-byte
+ * SRP session key; CMaNGOS TBC uses the same cipher with a 20-byte
+ * HMAC-derived key.
  *
  * Algorithm (encrypt):
  *   encrypted = (plaintext ^ key[index]) + previousEncrypted
@@ -27,10 +28,9 @@ public:
     ~VanillaCrypt() = default;
 
     /**
-     * Initialize the cipher with the raw session key
-     * @param sessionKey 40-byte session key from SRP auth
+     * Initialize the cipher with the packet-header key.
      */
-    void init(const std::vector<uint8_t>& sessionKey);
+    void init(const std::vector<uint8_t>& key);
 
     /**
      * Encrypt outgoing header bytes (CMSG: 6 bytes)

--- a/include/core/ui_screen_callback_handler.hpp
+++ b/include/core/ui_screen_callback_handler.hpp
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 namespace wowee {
 
@@ -40,6 +41,7 @@ private:
     SetStateFn setState_;
 
     std::string pendingCreatedCharacterName_;  // Auto-select after character creation
+    std::vector<uint8_t> authenticatedSessionKey_;
 };
 
 } // namespace core

--- a/include/network/world_socket.hpp
+++ b/include/network/world_socket.hpp
@@ -23,7 +23,7 @@ namespace network {
  * World Server Socket
  *
  * Handles WoW world server protocol with header encryption.
- * Supports both vanilla/TBC (XOR+addition cipher) and WotLK (RC4).
+ * Supports vanilla/classic raw XOR, CMaNGOS TBC HMAC-derived XOR, and WotLK RC4.
  *
  * Key Differences from Auth Server:
  * - Outgoing: 6-byte header (2 bytes size + 4 bytes opcode, big-endian)
@@ -69,7 +69,7 @@ public:
      * Must be called after CMSG_AUTH_SESSION before further communication
      *
      * @param sessionKey 40-byte session key from auth server
-     * @param build Client build number (determines cipher: <= 8606 = XOR, > 8606 = RC4)
+     * @param build Client build number (determines cipher family)
      */
     void initEncryption(const std::vector<uint8_t>& sessionKey, uint32_t build = 12340);
 

--- a/src/auth/auth_handler.cpp
+++ b/src/auth/auth_handler.cpp
@@ -293,7 +293,7 @@ void AuthHandler::sendLogonProof() {
             }
         }
 
-        const char* candidateExes[] = { "WoW.exe", "TurtleWoW.exe", "Wow.exe" };
+        const char* candidateExes[] = { "WoW.exe", "TurtleWoW.exe", "Wow.exe", "wow.exe" };
         bool ok = false;
         std::string lastErr;
         for (const auto& dir : candidateDirs) {

--- a/src/auth/auth_packets.cpp
+++ b/src/auth/auth_packets.cpp
@@ -351,7 +351,7 @@ network::Packet RealmListPacket::build() {
 
 bool RealmListResponseParser::parse(network::Packet& packet, RealmListResponse& response, uint8_t protocolVersion) {
     // Note: opcode byte already consumed by handlePacket()
-    const bool isVanilla = (protocolVersion < 8);
+    const bool isLegacyVanilla = (protocolVersion <= 3);
 
     // Packet size (2 bytes) - we already know the size, skip it
     uint16_t packetSize = packet.readUInt16();
@@ -360,9 +360,9 @@ bool RealmListResponseParser::parse(network::Packet& packet, RealmListResponse& 
     // Unknown uint32
     packet.readUInt32();
 
-    // Realm count: uint8 for vanilla/classic, uint16 for WotLK+
+    // Realm count: uint8 for legacy vanilla/classic, uint16 for TBC/WotLK.
     uint16_t realmCount;
-    if (isVanilla) {
+    if (isLegacyVanilla) {
         realmCount = packet.readUInt8();
     } else {
         realmCount = packet.readUInt16();
@@ -375,19 +375,15 @@ bool RealmListResponseParser::parse(network::Packet& packet, RealmListResponse& 
     for (uint16_t i = 0; i < realmCount; ++i) {
         Realm realm;
 
-        // Icon/type: uint32 for vanilla, uint8 for WotLK
-        if (isVanilla) {
+        // Icon/type: uint32 for legacy vanilla, uint8 for TBC/WotLK.
+        if (isLegacyVanilla) {
             realm.icon = static_cast<uint8_t>(packet.readUInt32());
         } else {
             realm.icon = packet.readUInt8();
         }
 
-        // Lock: not present in vanilla (added in TBC)
-        if (!isVanilla) {
-            realm.lock = packet.readUInt8();
-        } else {
-            realm.lock = 0;
-        }
+        // Lock is not present in legacy vanilla, but is present in TBC/WotLK.
+        realm.lock = isLegacyVanilla ? 0 : packet.readUInt8();
 
         // Flags
         realm.flags = packet.readUInt8();

--- a/src/auth/vanilla_crypt.cpp
+++ b/src/auth/vanilla_crypt.cpp
@@ -3,8 +3,8 @@
 namespace wowee {
 namespace auth {
 
-void VanillaCrypt::init(const std::vector<uint8_t>& sessionKey) {
-    key_ = sessionKey;
+void VanillaCrypt::init(const std::vector<uint8_t>& key) {
+    key_ = key;
     sendIndex_ = 0;
     sendPrev_ = 0;
     recvIndex_ = 0;

--- a/src/core/ui_screen_callback_handler.cpp
+++ b/src/core/ui_screen_callback_handler.cpp
@@ -27,6 +27,11 @@ UIScreenCallbackHandler::UIScreenCallbackHandler(
 }
 
 void UIScreenCallbackHandler::setupCallbacks() {
+    authHandler_.setOnSuccess([this](const std::vector<uint8_t>& sessionKey) {
+        authenticatedSessionKey_ = sessionKey;
+        LOG_INFO("Cached auth session key for world handoff (", authenticatedSessionKey_.size(), " bytes)");
+    });
+
     // Authentication screen callback
     uiManager_.getAuthScreen().setOnSuccess([this]() {
         LOG_INFO("Authentication successful, transitioning to realm selection");
@@ -49,7 +54,15 @@ void UIScreenCallbackHandler::setupCallbacks() {
         }
 
         // Connect to world server
-        const auto& sessionKey = authHandler_.getSessionKey();
+        auto sessionKey = authHandler_.getSessionKey();
+        if (sessionKey.empty() && !authenticatedSessionKey_.empty()) {
+            LOG_WARNING("Auth handler session key was empty at realm selection; using cached key");
+            sessionKey = authenticatedSessionKey_;
+        }
+        if (sessionKey.size() != 40) {
+            LOG_ERROR("Cannot connect to realm: auth session key has ", sessionKey.size(),
+                      " bytes; expected 40. Re-authenticate and try again.");
+        }
         std::string accountName = authHandler_.getUsername();
         if (accountName.empty()) {
             LOG_WARNING("Auth username missing; falling back to TESTACCOUNT");

--- a/src/game/warden_memory.cpp
+++ b/src/game/warden_memory.cpp
@@ -631,7 +631,7 @@ std::string WardenMemory::findWowExe(uint16_t build) const {
     candidateDirs.push_back("Data/misc");
     candidateDirs.push_back("Data/expansions/turtle/overlay/misc");
 
-    const char* candidateExes[] = { "WoW.exe", "TurtleWoW.exe", "Wow.exe" };
+    const char* candidateExes[] = { "WoW.exe", "TurtleWoW.exe", "Wow.exe", "wow.exe" };
 
     // Collect all candidate paths
     std::vector<std::string> allPaths;

--- a/src/network/world_socket.cpp
+++ b/src/network/world_socket.cpp
@@ -853,17 +853,29 @@ void WorldSocket::initEncryption(const std::vector<uint8_t>& sessionKey, uint32_
         return;
     }
 
-    // Vanilla/TBC (build <= 8606) uses XOR+addition cipher with raw session key
-    // WotLK (build > 8606) uses HMAC-SHA1 derived RC4 with 1024-byte drop
-    useVanillaCrypt = (build <= 8606);
+    const bool useRawVanillaCrypt = (build <= 5875);
+    const bool useCmangosTbcCrypt = (build > 5875 && build <= 8606);
+    useVanillaCrypt = useRawVanillaCrypt || useCmangosTbcCrypt;
 
-    LOG_INFO(">>> ENABLING ENCRYPTION (", useVanillaCrypt ? "vanilla XOR" : "WotLK RC4",
+    LOG_INFO(">>> ENABLING ENCRYPTION (",
+             useRawVanillaCrypt ? "vanilla XOR" : (useCmangosTbcCrypt ? "CMaNGOS TBC HMAC-XOR" : "WotLK RC4"),
              ") build=", build, " <<<");
 
-    if (useVanillaCrypt) {
+    if (useRawVanillaCrypt) {
         vanillaCrypt.init(sessionKey);
+    } else if (useCmangosTbcCrypt) {
+        // CMaNGOS TBC AuthCrypt::Init:
+        //   key = HMAC_SHA1({38 A7 83 15 F8 92 25 30 71 98 67 B1 8C 04 E2 AA}, K)
+        // Then the vanilla XOR+addition header cipher is used with that 20-byte key.
+        static constexpr uint8_t kCmangosTbcSeed[] = {
+            0x38, 0xA7, 0x83, 0x15, 0xF8, 0x92, 0x25, 0x30,
+            0x71, 0x98, 0x67, 0xB1, 0x8C, 0x04, 0xE2, 0xAA
+        };
+        std::vector<uint8_t> seed(kCmangosTbcSeed, kCmangosTbcSeed + sizeof(kCmangosTbcSeed));
+        std::vector<uint8_t> headerKey = auth::Crypto::hmacSHA1(seed, sessionKey);
+        vanillaCrypt.init(headerKey);
     } else {
-        // WotLK: HMAC-SHA1(hardcoded seed, sessionKey) → RC4 key
+        // WotLK: HMAC-SHA1(hardcoded seed, sessionKey) -> RC4 key
         std::vector<uint8_t> encryptKey(ENCRYPT_KEY, ENCRYPT_KEY + 16);
         std::vector<uint8_t> decryptKey(DECRYPT_KEY, DECRYPT_KEY + 16);
 

--- a/src/ui/realm_screen.cpp
+++ b/src/ui/realm_screen.cpp
@@ -231,8 +231,11 @@ void RealmScreen::setStatus(const std::string& message) {
 }
 
 const char* RealmScreen::getRealmStatus(uint8_t flags) const {
-    if (flags & 0x01) return "Invalid";
     if (flags & 0x02) return "Offline";
+    if (flags & 0x01) return "Invalid";
+    if (flags & 0x80) return "Full";
+    if (flags & 0x40) return "New";
+    if (flags & 0x20) return "Recommended";
     return "Online";
 }
 


### PR DESCRIPTION
## Issue
Character list would not enumerate correctly when connecting to CMaNGOS TBC Private Server. Was operating correctly using TBC 2.4.3 client.

## What
Fixes TBC/MaNGOS login path enough to authenticate, select a realm, and enumerate characters.

## Why
CMaNGOS TBC differs from the previous assumptions in realm-list parsing and world-header crypto. The client could authenticate but failed to enter the realm/character-list flow reliably.

## Tested
- Built locally on macOS with `cmake --build build --parallel 1`
- Tests ran with `./test.sh --test`
- Manual test against CMaNGOS TBC 2.4.3: realm list loads, world auth succeeds, characters enumerate