### PR TITLE
fix(tbc): parse group and world-state packets

### DIFF
--- a/include/game/world_packets.hpp
+++ b/include/game/world_packets.hpp
@@ -1978,7 +1978,9 @@ class GroupListParser {
 public:
     // hasRoles: WotLK 3.3.5a added a roles byte at group level and per-member for LFD.
     //           Classic 1.12 and TBC 2.4.3 do not send this byte.
-    static bool parse(network::Packet& packet, GroupListData& data, bool hasRoles = true);
+    // hasBattleGroupFlag: CMaNGOS TBC sends an extra battle-group byte after the raid flag.
+    static bool parse(network::Packet& packet, GroupListData& data,
+                      bool hasRoles = true, bool hasBattleGroupFlag = false);
 };
 
 /** SMSG_PARTY_COMMAND_RESULT data */

--- a/src/game/game_handler_packets.cpp
+++ b/src/game/game_handler_packets.cpp
@@ -921,8 +921,8 @@ void GameHandler::registerOpcodeHandlers() {
 
     // ---- SMSG_INIT_WORLD_STATES ----
     dispatchTable_[Opcode::SMSG_INIT_WORLD_STATES] = [this](network::Packet& packet) {
-        // WotLK format: uint32 mapId, uint32 zoneId, uint32 areaId, uint16 count, N*(uint32 key, uint32 val)
-        // Classic/TBC format: uint32 mapId, uint32 zoneId, uint16 count, N*(uint32 key, uint32 val)
+        // WotLK/TBC format: uint32 mapId, uint32 zoneId, uint32 areaId, uint16 count, N*(uint32 key, uint32 val)
+        // Classic format: uint32 mapId, uint32 zoneId, uint16 count, N*(uint32 key, uint32 val)
         if (!packet.hasRemaining(10)) {
             LOG_WARNING("SMSG_INIT_WORLD_STATES too short: ", packet.getSize(), " bytes");
             return;
@@ -938,11 +938,11 @@ void GameHandler::registerOpcodeHandlers() {
                 worldStateZoneId_ = newZoneId;
             }
         }
-        // WotLK adds areaId (uint32) before count; Classic/TBC/Turtle use the shorter format
+        // TBC added areaId in 2.1.0; WotLK kept it. Classic/Turtle use the shorter format.
         size_t remaining = packet.getRemainingSize();
-        bool isWotLKFormat = isActiveExpansion("wotlk");
-        if (isWotLKFormat && remaining >= 6) {
-            packet.readUInt32(); // areaId (WotLK only)
+        bool hasAreaId = isActiveExpansion("tbc") || isActiveExpansion("wotlk");
+        if (hasAreaId && remaining >= 6) {
+            packet.readUInt32(); // areaId
         }
         uint16_t count = packet.readUInt16();
         size_t needed = static_cast<size_t>(count) * 8;

--- a/src/game/social_handler.cpp
+++ b/src/game/social_handler.cpp
@@ -1238,10 +1238,11 @@ void SocialHandler::handleGroupDecline(network::Packet& packet) {
 
 void SocialHandler::handleGroupList(network::Packet& packet) {
     const bool hasRoles = isActiveExpansion("wotlk");
+    const bool hasBattleGroupFlag = isActiveExpansion("tbc");
     const uint8_t prevLootMethod = partyData.lootMethod;
     const bool wasInGroup = !partyData.isEmpty();
     partyData = GroupListData{};
-    if (!GroupListParser::parse(packet, partyData, hasRoles)) return;
+    if (!GroupListParser::parse(packet, partyData, hasRoles, hasBattleGroupFlag)) return;
 
     const bool nowInGroup = !partyData.isEmpty();
     if (!nowInGroup && wasInGroup) {

--- a/src/game/world_packets_world.cpp
+++ b/src/game/world_packets_world.cpp
@@ -357,13 +357,17 @@ network::Packet GroupDeclinePacket::build() {
     return packet;
 }
 
-bool GroupListParser::parse(network::Packet& packet, GroupListData& data, bool hasRoles) {
+bool GroupListParser::parse(network::Packet& packet, GroupListData& data,
+                            bool hasRoles, bool hasBattleGroupFlag) {
     auto rem = [&]() { return packet.getRemainingSize(); };
 
-    if (rem() < 3) return false;
+    if (rem() < (hasBattleGroupFlag ? 4u : 3u)) return false;
     data.groupType = packet.readUInt8();
-    data.subGroup  = packet.readUInt8();
-    data.flags     = packet.readUInt8();
+    if (hasBattleGroupFlag) {
+        packet.readUInt8(); // isBattleGroup, sent by CMaNGOS TBC before subgroup.
+    }
+    data.subGroup = packet.readUInt8();
+    data.flags    = packet.readUInt8();
 
     // WotLK 3.3.5a added a roles byte (tank/healer/dps) for the dungeon finder.
     // Classic 1.12 and TBC 2.4.3 do not have this byte.
@@ -385,9 +389,12 @@ bool GroupListParser::parse(network::Packet& packet, GroupListData& data, bool h
         }
     }
 
-    if (rem() < 12) return false;
+    if (rem() < 8) return false;
     packet.readUInt64(); // group GUID
-    packet.readUInt32(); // update counter
+    if (hasRoles) {
+        if (rem() < 4) return false;
+        packet.readUInt32(); // update counter (WotLK)
+    }
 
     if (rem() < 4) return false;
     data.memberCount = packet.readUInt32();


### PR DESCRIPTION
Handle CMaNGOS TBC group-list packets with the extra battle-group byte and without the WotLK update counter so member counts remain aligned.

Treat TBC init-world-states packets as carrying areaId before the state count, matching later TBC clients and avoiding truncated state-pair parsing.