### PR TITLE
fix(ui): align action bar pages and icons

### DIFF
--- a/include/game/game_handler.hpp
+++ b/include/game/game_handler.hpp
@@ -873,14 +873,14 @@ public:
     const std::unordered_map<uint32_t, TalentTabEntry>& getAllTalentTabs() const;
     void loadTalentDbc();
 
-    // Action bar — 4 bars × 12 slots = 48 total
-    // Bar 0 (slots  0-11): main bottom bar (1-0, -, =)
-    // Bar 1 (slots 12-23): second bar above main (Shift+1 ... Shift+=)
-    // Bar 2 (slots 24-35): right side vertical bar
-    // Bar 3 (slots 36-47): left side vertical bar
+    // Action bar — 12 pages × 12 slots = 144 total.
+    // The first 6 pages match FrameXML action pages:
+    // Page 1: main bar, pages 2-6: scrollable main pages / fixed multi-bars.
+    // TBC sends 132 slots; WotLK sends 144.  Keep the full WotLK-sized array so
+    // later pages are not discarded when loading server action buttons.
     static constexpr int SLOTS_PER_BAR    = 12;
-    static constexpr int ACTION_BARS      = 4;
-    static constexpr int ACTION_BAR_SLOTS = SLOTS_PER_BAR * ACTION_BARS;   // 48
+    static constexpr int ACTION_BARS      = 12;
+    static constexpr int ACTION_BAR_SLOTS = SLOTS_PER_BAR * ACTION_BARS;   // 144
     std::array<ActionBarSlot, ACTION_BAR_SLOTS>& getActionBar() { return actionBar; }
     const std::array<ActionBarSlot, ACTION_BAR_SLOTS>& getActionBar() const { return actionBar; }
     void setActionBarSlot(int slot, ActionBarSlot::Type type, uint32_t id);

--- a/include/ui/action_bar_panel.hpp
+++ b/include/ui/action_bar_panel.hpp
@@ -26,6 +26,15 @@ public:
     // Callback type for resolving spell icons (spellId, assetMgr) → VkDescriptorSet
     using SpellIconFn = std::function<VkDescriptorSet(uint32_t, pipeline::AssetManager*)>;
 
+    static constexpr int kFrameXmlActionBarPages = 6;
+    static constexpr int kBottomLeftActionPage = 6;
+    static constexpr int kRightActionPage = 3;
+    static constexpr int kLeftActionPage = 4;
+
+    static int actionSlotForPage(int page, int buttonIndex) {
+        return (page - 1) * 12 + buttonIndex;
+    }
+
     // ---- Action bar render methods ----
     void renderActionBar(game::GameHandler& gameHandler,
                          SettingsPanel& settingsPanel,
@@ -46,6 +55,8 @@ public:
     void renderRepBar(game::GameHandler& gameHandler,
                       SettingsPanel& settingsPanel);
 
+    int getMainActionBarPage() const { return mainActionBarPage_; }
+
     // ---- State owned by this panel ----
 
     // Action bar error-flash: spellId → wall-clock time (seconds) when the flash ends
@@ -55,6 +66,7 @@ public:
     // Action bar drag state (-1 = not dragging)
     int actionBarDragSlot_ = -1;
     VkDescriptorSet actionBarDragIcon_ = VK_NULL_HANDLE;
+    int mainActionBarPage_ = 1;  // FrameXML main pages are 1..6.
 
     // Bag bar state
     VkDescriptorSet backpackIconTexture_ = VK_NULL_HANDLE;

--- a/include/ui/game_screen.hpp
+++ b/include/ui/game_screen.hpp
@@ -182,7 +182,7 @@ private:
     std::unordered_map<uint32_t, VkDescriptorSet> spellIconCache_;
     // SpellIconID -> icon path (from SpellIcon.dbc)
     std::unordered_map<uint32_t, std::string> spellIconPaths_;
-    // SpellID -> SpellIconID (from Spell.dbc field 133)
+    // SpellID -> SpellIconID (from the active expansion's Spell.dbc layout)
     std::unordered_map<uint32_t, uint32_t> spellIconIds_;
     bool spellIconDbLoaded_ = false;
     VkDescriptorSet getSpellIcon(uint32_t spellId, pipeline::AssetManager* am);

--- a/include/ui/settings_panel.hpp
+++ b/include/ui/settings_panel.hpp
@@ -76,12 +76,12 @@ public:
     bool pendingUseOriginalSoundtrack = true;
 
     // ---- Pending action bar layout ----
-    bool pendingShowActionBar2 = true;   // Show second action bar above main bar
+    bool pendingShowActionBar2 = true;   // Show bottom-left extra action bar above main bar
     float pendingActionBarScale = 1.0f;  // Multiplier for action bar slot size (0.5–1.5)
     float pendingActionBar2OffsetX = 0.0f;  // Horizontal offset from default center position
     float pendingActionBar2OffsetY = 0.0f;  // Vertical offset from default (above bar 1)
-    bool pendingShowRightBar = false;   // Right-edge vertical action bar (bar 3, slots 24-35)
-    bool pendingShowLeftBar  = false;   // Left-edge vertical action bar (bar 4, slots 36-47)
+    bool pendingShowRightBar = false;   // Right-edge vertical action bar (FrameXML page 3)
+    bool pendingShowLeftBar  = false;   // Left-edge vertical action bar (FrameXML page 4)
     float pendingRightBarOffsetY = 0.0f;  // Vertical offset from screen center
     float pendingLeftBarOffsetY  = 0.0f;  // Vertical offset from screen center
 

--- a/src/core/application.cpp
+++ b/src/core/application.cpp
@@ -364,11 +364,14 @@ bool Application::initialize() {
                             uint32_t iconField = 133; // WotLK default
                             uint32_t idField = 0;
                             if (spellL) {
-                                uint32_t layoutIcon = (*spellL)["IconID"];
-                                if (layoutIcon < fieldCount && fieldCount <= layoutIcon + 20) {
-                                    iconField = layoutIcon;
-                                    idField = (*spellL)["ID"];
-                                }
+                                try {
+                                    uint32_t layoutId = (*spellL)["ID"];
+                                    uint32_t layoutIcon = (*spellL)["IconID"];
+                                    if (layoutId < fieldCount && layoutIcon < fieldCount) {
+                                        iconField = layoutIcon;
+                                        idField = layoutId;
+                                    }
+                                } catch (...) {}
                             }
                             for (uint32_t i = 0; i < spellDbc->getRecordCount(); i++) {
                                 uint32_t id = spellDbc->getUInt32(i, idField);

--- a/src/ui/action_bar_panel.cpp
+++ b/src/ui/action_bar_panel.cpp
@@ -183,12 +183,9 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
     float barX = (screenW - barW) / 2.0f;
     float barY = screenH - barH;
 
-    ImGui::SetNextWindowPos(ImVec2(barX, barY), ImGuiCond_Always);
-    ImGui::SetNextWindowSize(ImVec2(barW, barH), ImGuiCond_Always);
-
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoResize | ImGuiWindowFlags_NoMove |
                              ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoTitleBar |
-                             ImGuiWindowFlags_NoScrollbar;
+                             ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoSavedSettings;
 
     ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, 4.0f);
     ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(padding, padding));
@@ -199,12 +196,11 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
     // Per-slot rendering lambda — shared by both action bars
     const auto& bar = gameHandler.getActionBar();
     static constexpr const char* keyLabels1[] = {"1","2","3","4","5","6","7","8","9","0","-","="};
-    // "⇧N" labels for bar 2 (UTF-8: E2 87 A7 = U+21E7 UPWARDS WHITE ARROW)
-    static constexpr const char* keyLabels2[] = {
-        "\xe2\x87\xa7" "1", "\xe2\x87\xa7" "2", "\xe2\x87\xa7" "3",
-        "\xe2\x87\xa7" "4", "\xe2\x87\xa7" "5", "\xe2\x87\xa7" "6",
-        "\xe2\x87\xa7" "7", "\xe2\x87\xa7" "8", "\xe2\x87\xa7" "9",
-        "\xe2\x87\xa7" "0", "\xe2\x87\xa7" "-", "\xe2\x87\xa7" "="
+
+    auto changeMainPage = [&](int delta) {
+        mainActionBarPage_ += delta;
+        if (mainActionBarPage_ < 1) mainActionBarPage_ = kFrameXmlActionBarPages;
+        if (mainActionBarPage_ > kFrameXmlActionBarPages) mainActionBarPage_ = 1;
     };
 
     auto renderBarSlot = [&](int absSlot, const char* keyLabel) {
@@ -872,11 +868,15 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
         ImGui::EndGroup();
     };
 
-    // Bar 2 (slots 12-23) — only show if at least one slot is populated
-    if (settingsPanel.pendingShowActionBar2) {
-        bool bar2HasContent = false;
-        for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i)
-            if (!bar[game::GameHandler::SLOTS_PER_BAR + i].isEmpty()) { bar2HasContent = true; break; }
+    // Bottom-left extra bar (FrameXML page 6, slots 60-71)
+    bool bottomLeftBarHasContent = false;
+    for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
+        if (!bar[actionSlotForPage(kBottomLeftActionPage, i)].isEmpty()) {
+            bottomLeftBarHasContent = true;
+            break;
+        }
+    }
+    if (settingsPanel.pendingShowActionBar2 && bottomLeftBarHasContent) {
 
         float bar2X = barX + settingsPanel.pendingActionBar2OffsetX;
         float bar2Y = barY - barH - 2.0f + settingsPanel.pendingActionBar2OffsetY;
@@ -886,12 +886,11 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
         ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding, ImVec2(padding, padding));
         ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(0.0f, 0.0f));
         ImGui::PushStyleVar(ImGuiStyleVar_WindowBorderSize, 0.0f);
-        ImGui::PushStyleColor(ImGuiCol_WindowBg,
-            bar2HasContent ? ImVec4(0.05f, 0.05f, 0.05f, 0.85f) : ImVec4(0.05f, 0.05f, 0.05f, 0.4f));
+        ImGui::PushStyleColor(ImGuiCol_WindowBg, ImVec4(0.05f, 0.05f, 0.05f, 0.85f));
         if (ImGui::Begin("##ActionBar2", nullptr, flags)) {
             for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
                 if (i > 0) ImGui::SameLine(0, spacing);
-                renderBarSlot(game::GameHandler::SLOTS_PER_BAR + i, keyLabels2[i]);
+                renderBarSlot(actionSlotForPage(kBottomLeftActionPage, i), "");
             }
         }
         ImGui::End();
@@ -899,11 +898,15 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
         ImGui::PopStyleVar(4);
     }
 
-    // Bar 1 (slots 0-11)
+    // Main action bar (FrameXML pages 1-6)
+    bool mainBarHovered = false;
+    ImGui::SetNextWindowPos(ImVec2(barX, barY), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(barW, barH), ImGuiCond_Always);
     if (ImGui::Begin("##ActionBar", nullptr, flags)) {
+        mainBarHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem);
         for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
             if (i > 0) ImGui::SameLine(0, spacing);
-            renderBarSlot(i, keyLabels1[i]);
+            renderBarSlot(actionSlotForPage(mainActionBarPage_, i), keyLabels1[i]);
         }
 
         // Macro editor modal — opened by "Edit" in action bar context menus
@@ -931,14 +934,39 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
     }
     ImGui::End();
 
+    if (mainBarHovered) {
+        float wheel = ImGui::GetIO().MouseWheel;
+        if (wheel > 0.0f) changeMainPage(-1);
+        else if (wheel < 0.0f) changeMainPage(1);
+    }
+
+    const float pagerW = 34.0f;
+    ImGui::SetNextWindowPos(ImVec2(barX + barW + 4.0f, barY), ImGuiCond_Always);
+    ImGui::SetNextWindowSize(ImVec2(pagerW, barH), ImGuiCond_Always);
+    if (ImGui::Begin("##ActionBarPager", nullptr, flags)) {
+        const float buttonH = std::max(16.0f, (barH - padding * 2.0f - 18.0f) * 0.5f);
+        if (ImGui::Button("^", ImVec2(pagerW - padding * 2.0f, buttonH))) {
+            changeMainPage(-1);
+        }
+        char pageText[8];
+        snprintf(pageText, sizeof(pageText), "%d/%d", mainActionBarPage_, kFrameXmlActionBarPages);
+        ImVec2 textSize = ImGui::CalcTextSize(pageText);
+        ImGui::SetCursorPosX((pagerW - textSize.x) * 0.5f);
+        ImGui::TextUnformatted(pageText);
+        if (ImGui::Button("v", ImVec2(pagerW - padding * 2.0f, buttonH))) {
+            changeMainPage(1);
+        }
+    }
+    ImGui::End();
+
     ImGui::PopStyleColor();
     ImGui::PopStyleVar(4);
 
-    // Right side vertical bar (bar 3, slots 24-35)
+    // Right side vertical bar (FrameXML page 3, slots 24-35)
     if (settingsPanel.pendingShowRightBar) {
         bool bar3HasContent = false;
         for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i)
-            if (!bar[game::GameHandler::SLOTS_PER_BAR * 2 + i].isEmpty()) { bar3HasContent = true; break; }
+            if (!bar[actionSlotForPage(kRightActionPage, i)].isEmpty()) { bar3HasContent = true; break; }
 
         float sideBarW = slotSize + padding * 2;
         float sideBarH = game::GameHandler::SLOTS_PER_BAR * slotSize + (game::GameHandler::SLOTS_PER_BAR - 1) * spacing + padding * 2;
@@ -955,7 +983,7 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
             bar3HasContent ? ImVec4(0.05f, 0.05f, 0.05f, 0.85f) : ImVec4(0.05f, 0.05f, 0.05f, 0.4f));
         if (ImGui::Begin("##ActionBarRight", nullptr, flags)) {
             for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
-                renderBarSlot(game::GameHandler::SLOTS_PER_BAR * 2 + i, "");
+                renderBarSlot(actionSlotForPage(kRightActionPage, i), "");
             }
         }
         ImGui::End();
@@ -963,11 +991,11 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
         ImGui::PopStyleVar(4);
     }
 
-    // Left side vertical bar (bar 4, slots 36-47)
+    // Left side vertical bar (FrameXML page 4, slots 36-47)
     if (settingsPanel.pendingShowLeftBar) {
         bool bar4HasContent = false;
         for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i)
-            if (!bar[game::GameHandler::SLOTS_PER_BAR * 3 + i].isEmpty()) { bar4HasContent = true; break; }
+            if (!bar[actionSlotForPage(kLeftActionPage, i)].isEmpty()) { bar4HasContent = true; break; }
 
         float sideBarW = slotSize + padding * 2;
         float sideBarH = game::GameHandler::SLOTS_PER_BAR * slotSize + (game::GameHandler::SLOTS_PER_BAR - 1) * spacing + padding * 2;
@@ -984,7 +1012,7 @@ void ActionBarPanel::renderActionBar(game::GameHandler& gameHandler,
             bar4HasContent ? ImVec4(0.05f, 0.05f, 0.05f, 0.85f) : ImVec4(0.05f, 0.05f, 0.05f, 0.4f));
         if (ImGui::Begin("##ActionBarLeft", nullptr, flags)) {
             for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
-                renderBarSlot(game::GameHandler::SLOTS_PER_BAR * 3 + i, "");
+                renderBarSlot(actionSlotForPage(kLeftActionPage, i), "");
             }
         }
         ImGui::End();
@@ -1497,7 +1525,17 @@ void ActionBarPanel::renderXpBar(game::GameHandler& gameHandler,
     // bar2 top edge (when visible): bar1 top - barH - 2 + bar2 vertical offset
     float bar1TopY = screenH - barH;
     float xpBarY;
+    bool bottomLeftBarVisible = false;
     if (settingsPanel.pendingShowActionBar2) {
+        const auto& bar = gameHandler.getActionBar();
+        for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
+            if (!bar[actionSlotForPage(kBottomLeftActionPage, i)].isEmpty()) {
+                bottomLeftBarVisible = true;
+                break;
+            }
+        }
+    }
+    if (bottomLeftBarVisible) {
         float bar2TopY = bar1TopY - barH - 2.0f + settingsPanel.pendingActionBar2OffsetY;
         xpBarY = bar2TopY - xpBarH - 2.0f;
     } else {
@@ -1682,7 +1720,17 @@ void ActionBarPanel::renderRepBar(game::GameHandler& gameHandler,
 
     float bar1TopY = screenH - barH_ab;
     float xpBarY;
+    bool bottomLeftBarVisible = false;
     if (settingsPanel.pendingShowActionBar2) {
+        const auto& bar = gameHandler.getActionBar();
+        for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
+            if (!bar[actionSlotForPage(kBottomLeftActionPage, i)].isEmpty()) {
+                bottomLeftBarVisible = true;
+                break;
+            }
+        }
+    }
+    if (bottomLeftBarVisible) {
         float bar2TopY = bar1TopY - barH_ab - 2.0f + settingsPanel.pendingActionBar2OffsetY;
         xpBarY = bar2TopY - xpBarH - 2.0f;
     } else {

--- a/src/ui/game_screen.cpp
+++ b/src/ui/game_screen.cpp
@@ -1065,7 +1065,9 @@ void GameScreen::processTargetInput(game::GameHandler& gameHandler) {
 
             for (int i = 0; i < game::GameHandler::SLOTS_PER_BAR; ++i) {
                 if (!ctrlDown && input.isKeyJustPressed(actionBarKeys[i])) {
-                    int slotIdx = shiftDown ? (game::GameHandler::SLOTS_PER_BAR + i) : i;
+                    int slotIdx = shiftDown
+                        ? ActionBarPanel::actionSlotForPage(ActionBarPanel::kBottomLeftActionPage, i)
+                        : ActionBarPanel::actionSlotForPage(actionBarPanel_.getMainActionBarPage(), i);
                     if (bar[slotIdx].type == game::ActionBarSlot::SPELL && bar[slotIdx].isReady()) {
                         uint64_t target = gameHandler.hasTarget() ? gameHandler.getTargetGuid() : 0;
                         gameHandler.castSpell(bar[slotIdx].id, target);

--- a/src/ui/game_screen_hud.cpp
+++ b/src/ui/game_screen_hud.cpp
@@ -517,21 +517,21 @@ VkDescriptorSet GameScreen::getSpellIcon(uint32_t spellId, pipeline::AssetManage
                 }
             };
 
-            // Use expansion-aware layout if available AND the DBC field count
-            // matches the expansion's expected format.  Classic=173, TBC=216,
-            // WotLK=234 fields.  When Classic is active but the base WotLK DBC
-            // is loaded (234 fields), field 117 is NOT IconID — we must use
-            // the WotLK field 133 instead.
+            // Use the active expansion layout when its fields are present in
+            // the loaded DBC. TBC/WotLK/Classic place IconID in different
+            // columns, so reading the WotLK default for every client leaves
+            // action bars and spell UI without icons.
             uint32_t iconField = 133; // WotLK default
             uint32_t idField = 0;
             if (spellL) {
-                uint32_t layoutIcon = (*spellL)["IconID"];
-                // Only trust the expansion layout if the DBC has a compatible
-                // field count (within ~20 of the layout's icon field).
-                if (layoutIcon < fieldCount && fieldCount <= layoutIcon + 20) {
-                    iconField = layoutIcon;
-                    idField = (*spellL)["ID"];
-                }
+                try {
+                    uint32_t layoutId = (*spellL)["ID"];
+                    uint32_t layoutIcon = (*spellL)["IconID"];
+                    if (layoutId < fieldCount && layoutIcon < fieldCount) {
+                        iconField = layoutIcon;
+                        idField = layoutId;
+                    }
+                } catch (...) {}
             }
             tryLoadIcons(idField, iconField);
         }

--- a/src/ui/settings_panel.cpp
+++ b/src/ui/settings_panel.cpp
@@ -54,15 +54,15 @@ if (ImGui::SliderFloat("Action Bar Scale", &pendingActionBarScale, 0.5f, 1.5f, "
 }
 ImGui::Spacing();
 
-if (ImGui::Checkbox("Show Second Action Bar", &pendingShowActionBar2)) {
+if (ImGui::Checkbox("Show Bottom Left Bar", &pendingShowActionBar2)) {
     saveCallback();
 }
 ImGui::SameLine();
-ImGui::TextDisabled("(Shift+1 through Shift+=)");
+ImGui::TextDisabled("(client action page 6)");
 
 if (pendingShowActionBar2) {
     ImGui::Spacing();
-    ImGui::TextUnformatted("Second Bar Position Offset");
+    ImGui::TextUnformatted("Bottom Left Bar Position Offset");
     ImGui::SetNextItemWidth(160.0f);
     if (ImGui::SliderFloat("Horizontal##bar2x", &pendingActionBar2OffsetX, -600.0f, 600.0f, "%.0f px")) {
         saveCallback();
@@ -83,7 +83,7 @@ if (ImGui::Checkbox("Show Right Side Bar", &pendingShowRightBar)) {
     saveCallback();
 }
 ImGui::SameLine();
-ImGui::TextDisabled("(Slots 25-36)");
+ImGui::TextDisabled("(client action page 3)");
 if (pendingShowRightBar) {
     ImGui::SetNextItemWidth(160.0f);
     if (ImGui::SliderFloat("Vertical Offset##rbar", &pendingRightBarOffsetY, -400.0f, 400.0f, "%.0f px")) {
@@ -96,7 +96,7 @@ if (ImGui::Checkbox("Show Left Side Bar", &pendingShowLeftBar)) {
     saveCallback();
 }
 ImGui::SameLine();
-ImGui::TextDisabled("(Slots 37-48)");
+ImGui::TextDisabled("(client action page 4)");
 if (pendingShowLeftBar) {
     ImGui::SetNextItemWidth(160.0f);
     if (ImGui::SliderFloat("Vertical Offset##lbar", &pendingLeftBarOffsetY, -400.0f, 400.0f, "%.0f px")) {

--- a/src/ui/talent_screen.cpp
+++ b/src/ui/talent_screen.cpp
@@ -615,16 +615,20 @@ void TalentScreen::loadSpellDBC(pipeline::AssetManager* assetManager) {
 
     const auto* spellL = pipeline::getActiveDBCLayout() ? pipeline::getActiveDBCLayout()->getLayout("Spell") : nullptr;
     uint32_t fieldCount = dbc->getFieldCount();
-    // Detect DBC/layout mismatch: Classic layout expects ~173 fields but we may
-    // load the WotLK base DBC (234 fields).  Use WotLK field indices in that case.
     uint32_t idField = 0, iconField = 133, tooltipField = 139;
     if (spellL) {
-        uint32_t layoutIcon = (*spellL)["IconID"];
-        if (layoutIcon < fieldCount && fieldCount <= layoutIcon + 20) {
-            idField = (*spellL)["ID"];
-            iconField = layoutIcon;
-            try { tooltipField = (*spellL)["Tooltip"]; } catch (...) {}
-        }
+        try {
+            uint32_t layoutId = (*spellL)["ID"];
+            uint32_t layoutIcon = (*spellL)["IconID"];
+            if (layoutId < fieldCount && layoutIcon < fieldCount) {
+                idField = layoutId;
+                iconField = layoutIcon;
+                try {
+                    uint32_t layoutTooltip = (*spellL)["Tooltip"];
+                    if (layoutTooltip < fieldCount) tooltipField = layoutTooltip;
+                } catch (...) {}
+            }
+        } catch (...) {}
     }
     uint32_t count = dbc->getRecordCount();
     for (uint32_t i = 0; i < count; ++i) {


### PR DESCRIPTION
## Summary

Fixes action bar page mapping and spell icon resolution for TBC clients.

- Expands stored action bar slots from 48 to 144 so server-provided action buttons beyond the first four bars are preserved.
- Maps the main action bar to FrameXML pages 1-6, with pager controls and mouse-wheel page switching.
- Moves the populated bottom-left bar to the expected bottom action bar area instead of rendering the scrollable main page near the top-left.
- Uses expansion-aware `Spell.dbc` layouts when resolving spell icons, so TBC action buttons display icons instead of text fallbacks.
- Updates action-bar settings labels to describe the client action pages being shown.

## Testing

- `git diff --check`
- `cmake --build build --target wowee --parallel 2`
- `./test.sh --test`
- Playtested against a TBC CMaNGOS realm: action bar pages scroll correctly, the bottom bar appears in the expected location, and spell action buttons render icons.