### PR TITLE
fix(ui): stabilize bag windows and talent tab counts

### DIFF
--- a/include/game/game_handler.hpp
+++ b/include/game/game_handler.hpp
@@ -862,10 +862,12 @@ public:
 
     // Talent DBC access
     const TalentEntry* getTalentEntry(uint32_t talentId) const {
+        if (spellHandler_) return spellHandler_->getTalentEntry(talentId);
         auto it = talentCache_.find(talentId);
         return (it != talentCache_.end()) ? &it->second : nullptr;
     }
     const TalentTabEntry* getTalentTabEntry(uint32_t tabId) const {
+        if (spellHandler_) return spellHandler_->getTalentTabEntry(tabId);
         auto it = talentTabCache_.find(tabId);
         return (it != talentTabCache_.end()) ? &it->second : nullptr;
     }

--- a/include/ui/inventory_screen.hpp
+++ b/include/ui/inventory_screen.hpp
@@ -197,6 +197,12 @@ private:
     int splitCount_ = 1;
     std::string splitItemName_;
 
+    // ImGui starts window movement before item widgets run for the frame, so
+    // keep bag windows title-bar-draggable while bags are open.
+    bool bagMoveConfigActive_ = false;
+    bool previousMoveFromTitleBarOnly_ = false;
+    void setBagMoveConfigActive(bool active);
+
     // Server-side bag sort swap queue (one swap per frame)
     std::deque<game::Inventory::SwapOp> sortSwapQueue_;
 

--- a/src/ui/inventory_screen.cpp
+++ b/src/ui/inventory_screen.cpp
@@ -133,8 +133,28 @@ const game::ItemSlot* findComparableEquipped(const game::Inventory& inventory, u
 } // namespace
 
 InventoryScreen::~InventoryScreen() {
+    setBagMoveConfigActive(false);
     // Vulkan textures are owned by VkContext and cleaned up on shutdown
     iconCache_.clear();
+}
+
+void InventoryScreen::setBagMoveConfigActive(bool active) {
+    if (!ImGui::GetCurrentContext()) {
+        bagMoveConfigActive_ = false;
+        return;
+    }
+
+    ImGuiIO& io = ImGui::GetIO();
+    if (active) {
+        if (!bagMoveConfigActive_) {
+            previousMoveFromTitleBarOnly_ = io.ConfigWindowsMoveFromTitleBarOnly;
+            bagMoveConfigActive_ = true;
+        }
+        io.ConfigWindowsMoveFromTitleBarOnly = true;
+    } else if (bagMoveConfigActive_) {
+        io.ConfigWindowsMoveFromTitleBarOnly = previousMoveFromTitleBarOnly_;
+        bagMoveConfigActive_ = false;
+    }
 }
 
 ImVec4 InventoryScreen::getQualityColor(game::ItemQuality quality) {
@@ -794,9 +814,12 @@ void InventoryScreen::render(game::Inventory& inventory, uint64_t moneyCopper) {
     }
 
     if (!open) {
+        setBagMoveConfigActive(false);
         if (holdingItem) cancelPickup(inventory);
         return;
     }
+
+    setBagMoveConfigActive(true);
 
     // Escape cancels held item
     if (holdingItem && !wantsTextInput && core::Input::getInstance().isKeyPressed(SDL_SCANCODE_ESCAPE)) {
@@ -972,7 +995,10 @@ void InventoryScreen::renderAggregateBags(game::Inventory& inventory, uint64_t m
     ImGui::SetNextWindowSize(ImVec2(windowW, windowH), ImGuiCond_Always);
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize;
-    if (!ImGui::Begin("Bags", &open, flags)) {
+    if (holdingItem || pickupPending_) flags |= ImGuiWindowFlags_NoMove;
+
+    bool windowVisible = ImGui::Begin("Bags", &open, flags);
+    if (!windowVisible) {
         ImGui::End();
         return;
     }
@@ -1037,7 +1063,7 @@ void InventoryScreen::renderSeparateBags(game::Inventory& inventory, uint64_t mo
         int bpUsed = 0;
         for (int i = 0; i < bpTotal; ++i) if (!inventory.getBackpackSlot(i).empty()) ++bpUsed;
         char bpTitle[64];
-        snprintf(bpTitle, sizeof(bpTitle), "Backpack (%d/%d)##backpack", bpUsed, bpTotal);
+        snprintf(bpTitle, sizeof(bpTitle), "Backpack (%d/%d)###backpack", bpUsed, bpTotal);
         int bpRows = (bpTotal + columns - 1) / columns;
         float bpH = bpRows * (slotSize + 4.0f) + 80.0f; // header + money + padding
         if (showKeyring_) {
@@ -1083,9 +1109,9 @@ void InventoryScreen::renderSeparateBags(game::Inventory& inventory, uint64_t mo
         game::EquipSlot bagSlot = static_cast<game::EquipSlot>(static_cast<int>(game::EquipSlot::BAG1) + bag);
         const auto& bagItem = inventory.getEquipSlot(bagSlot);
         if (!bagItem.empty() && !bagItem.item.name.empty()) {
-            snprintf(title, sizeof(title), "%s (%d/%d)##bag%d", bagItem.item.name.c_str(), bagUsed, bagSize, bag);
+            snprintf(title, sizeof(title), "%s (%d/%d)###bag%d", bagItem.item.name.c_str(), bagUsed, bagSize, bag);
         } else {
-            snprintf(title, sizeof(title), "Bag Slot %d (%d/%d)##bag%d", bag + 1, bagUsed, bagSize, bag);
+            snprintf(title, sizeof(title), "Bag Slot %d (%d/%d)###bag%d", bag + 1, bagUsed, bagSize, bag);
         }
 
         renderBagWindow(title, bagOpen_[bag], inventory, bag, stackX, defaultY, 0);
@@ -1138,7 +1164,10 @@ void InventoryScreen::renderBagWindow(const char* title, bool& isOpen,
     ImGui::SetNextWindowSize(ImVec2(windowW, windowH), ImGuiCond_Always);
 
     ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse | ImGuiWindowFlags_NoResize;
-    if (!ImGui::Begin(title, &isOpen, flags)) {
+    if (holdingItem || pickupPending_) flags |= ImGuiWindowFlags_NoMove;
+
+    bool windowVisible = ImGui::Begin(title, &isOpen, flags);
+    if (!windowVisible) {
         ImGui::End();
         return;
     }


### PR DESCRIPTION
## Summary

Improves a few TBC UI polish issues found during playtesting:

- Shows accurate spent talent counts on talent tree tabs.
- Stabilizes bag window IDs so separate bags keep their own positions.
- Prevents bag windows from re-anchoring/jumping while dragging items.
- Keeps bag movement constrained to the title bar instead of item slots.

## Testing

- Built successfully with `cmake --build build --target wowee -j 2`.
- Playtested bag opening/dragging and talent tree tab counts on TBC.