### PR TITLE
fix(tbc): support mining and gather object interactions

### DIFF
--- a/include/game/game_handler.hpp
+++ b/include/game/game_handler.hpp
@@ -1452,6 +1452,11 @@ public:
     void lootTarget(uint64_t guid);
     void lootItem(uint8_t slotIndex);
     void closeLoot();
+    void scheduleGameObjectLootOpen(uint64_t guid, float delaySeconds = 0.35f, uint8_t attempts = 1);
+    void clearPendingGameObjectLootOpen(uint64_t guid);
+    bool hasPendingGameObjectLootOpen(uint64_t guid) const;
+    bool isGatherGameObject(uint64_t guid) const;
+    void despawnGameObjectLocally(uint64_t guid);
     void activateSpiritHealer(uint64_t npcGuid);
     bool isLootWindowOpen() const;
     const LootResponseData& getCurrentLoot() const;
@@ -3137,6 +3142,7 @@ private:
     struct PendingLootOpen {
         uint64_t guid = 0;
         float timer = 0.0f;
+        uint8_t remainingAttempts = 1;
     };
     std::vector<PendingLootOpen> pendingGameObjectLootOpens_;
     // Tracks the last GO we sent CMSG_GAMEOBJ_USE to; used in handleSpellGo

--- a/include/game/inventory_handler.hpp
+++ b/include/game/inventory_handler.hpp
@@ -308,19 +308,6 @@ private:
         bool itemAutoLootSent = false;
     };
     std::unordered_map<uint64_t, LocalLootState> localLootState_;
-    struct PendingLootRetry {
-        uint64_t guid = 0;
-        float timer = 0.0f;
-        uint8_t remainingRetries = 0;
-        bool sendLoot = false;
-    };
-    std::vector<PendingLootRetry> pendingGameObjectLootRetries_;
-    struct PendingLootOpen {
-        uint64_t guid = 0;
-        float timer = 0.0f;
-    };
-    std::vector<PendingLootOpen> pendingGameObjectLootOpens_;
-    uint64_t lastInteractedGoGuid_ = 0;
     uint64_t pendingLootMoneyGuid_ = 0;
     uint32_t pendingLootMoneyAmount_ = 0;
     float pendingLootMoneyNotifyTimer_ = 0.0f;

--- a/include/game/packet_parsers.hpp
+++ b/include/game/packet_parsers.hpp
@@ -54,6 +54,11 @@ public:
         return CastSpellPacket::build(spellId, targetGuid, castCount);
     }
 
+    /** Build CMSG_CAST_SPELL with SpellCastTargets targeting a game object. */
+    virtual network::Packet buildCastGameObjectSpell(uint32_t spellId, uint64_t targetGuid, uint8_t castCount) {
+        return CastSpellPacket::buildGameObjectTarget(spellId, targetGuid, castCount);
+    }
+
     /** Build CMSG_USE_ITEM (WotLK default: bag + slot + castCount + spellId + itemGuid + glyphIndex + castFlags + targets) */
     virtual network::Packet buildUseItem(uint8_t bagIndex, uint8_t slotIndex,
                                          uint64_t itemGuid, uint32_t spellId = 0,
@@ -336,6 +341,7 @@ public:
     network::Packet buildAcceptQuestPacket(uint64_t npcGuid, uint32_t questId) override;
     // TBC 2.4.3 CMSG_CAST_SPELL has no castFlags byte (WotLK added it)
     network::Packet buildCastSpell(uint32_t spellId, uint64_t targetGuid, uint8_t castCount) override;
+    network::Packet buildCastGameObjectSpell(uint32_t spellId, uint64_t targetGuid, uint8_t castCount) override;
     // TBC 2.4.3 CMSG_USE_ITEM uses spellIndex + castCount + itemGuid + targets.
     network::Packet buildUseItem(uint8_t bagIndex, uint8_t slotIndex,
                                  uint64_t itemGuid, uint32_t spellId = 0,
@@ -418,6 +424,7 @@ public:
                                          const MovementInfo& info,
                                          uint64_t playerGuid = 0) override;
     network::Packet buildCastSpell(uint32_t spellId, uint64_t targetGuid, uint8_t castCount) override;
+    network::Packet buildCastGameObjectSpell(uint32_t spellId, uint64_t targetGuid, uint8_t castCount) override;
     network::Packet buildUseItem(uint8_t bagIndex, uint8_t slotIndex,
                                  uint64_t itemGuid, uint32_t spellId = 0,
                                  uint64_t targetGuid = 0) override;

--- a/include/game/world_packets.hpp
+++ b/include/game/world_packets.hpp
@@ -1839,6 +1839,7 @@ public:
 class CastSpellPacket {
 public:
     static network::Packet build(uint32_t spellId, uint64_t targetGuid, uint8_t castCount);
+    static network::Packet buildGameObjectTarget(uint32_t spellId, uint64_t targetGuid, uint8_t castCount);
 };
 
 /** CMSG_CANCEL_AURA packet builder */

--- a/src/game/game_handler.cpp
+++ b/src/game/game_handler.cpp
@@ -660,7 +660,13 @@ void GameHandler::updateTimers(float deltaTime) {
                 }
                 lootTarget(it->guid);
             }
-            it = pendingGameObjectLootOpens_.erase(it);
+            if (it->remainingAttempts > 1) {
+                --it->remainingAttempts;
+                it->timer = 0.75f;
+                ++it;
+            } else {
+                it = pendingGameObjectLootOpens_.erase(it);
+            }
         } else {
             ++it;
         }

--- a/src/game/game_handler_callbacks.cpp
+++ b/src/game/game_handler_callbacks.cpp
@@ -79,6 +79,71 @@ const char* worldStateName(WorldState state) {
     return "UNKNOWN";
 }
 
+std::string lowerCopy(std::string value) {
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return value;
+}
+
+bool containsAnyTerm(const std::string& haystack, const char* const* terms, size_t count) {
+    for (size_t i = 0; i < count; ++i) {
+        if (haystack.find(terms[i]) != std::string::npos) return true;
+    }
+    return false;
+}
+
+uint32_t gatherSpellForGameObject(const GameObjectQueryResponseData* info, const std::string& name) {
+    if (info && info->type != 3) return 0; // GAMEOBJECT_TYPE_CHEST
+
+    const std::string lower = lowerCopy(name);
+    static constexpr const char* kMiningTerms[] = {
+        "vein", "deposit", "mineral"
+    };
+    static constexpr const char* kHerbTerms[] = {
+        "peacebloom", "silverleaf", "earthroot", "mageroyal", "briarthorn",
+        "stranglekelp", "bruiseweed", "steelbloom", "grave moss", "kingsblood",
+        "liferoot", "fadeleaf", "goldthorn", "khadgar", "wintersbite",
+        "firebloom", "purple lotus", "arthas", "sungrass", "blindweed",
+        "ghost mushroom", "gromsblood", "dreamfoil", "silversage",
+        "plaguebloom", "icecap", "black lotus", "felweed", "dreaming glory",
+        "terocone", "ragveil", "ancient lichen", "netherbloom",
+        "nightmare vine", "mana thistle"
+    };
+
+    if (containsAnyTerm(lower, kMiningTerms, sizeof(kMiningTerms) / sizeof(kMiningTerms[0]))) return 2575; // Mining
+    if (containsAnyTerm(lower, kHerbTerms, sizeof(kHerbTerms) / sizeof(kHerbTerms[0]))) return 2366; // Herb Gathering
+    return 0;
+}
+
+uint32_t knownGatherRank(const SpellHandler* spellHandler, uint32_t baseSpellId) {
+    if (!spellHandler) return 0;
+
+    static constexpr uint32_t kMiningRanks[] = {
+        2575, 2576, 3564, 10248, 29354
+    };
+    static constexpr uint32_t kHerbRanks[] = {
+        2366, 2368, 3570, 11993, 28695
+    };
+
+    const uint32_t* ranks = nullptr;
+    size_t count = 0;
+    if (baseSpellId == kMiningRanks[0]) {
+        ranks = kMiningRanks;
+        count = sizeof(kMiningRanks) / sizeof(kMiningRanks[0]);
+    } else if (baseSpellId == kHerbRanks[0]) {
+        ranks = kHerbRanks;
+        count = sizeof(kHerbRanks) / sizeof(kHerbRanks[0]);
+    } else {
+        return 0;
+    }
+
+    for (size_t i = count; i > 0; --i) {
+        const uint32_t spellId = ranks[i - 1];
+        if (spellHandler->hasKnownSpell(spellId)) return spellId;
+    }
+    return 0;
+}
+
 } // end anonymous namespace
 
 void GameHandler::handleAuthChallenge(network::Packet& packet) {
@@ -1954,6 +2019,62 @@ void GameHandler::closeLoot() {
     if (inventoryHandler_) inventoryHandler_->closeLoot();
 }
 
+void GameHandler::scheduleGameObjectLootOpen(uint64_t guid, float delaySeconds, uint8_t attempts) {
+    if (guid == 0) return;
+    clearPendingGameObjectLootOpen(guid);
+    PendingLootOpen pending;
+    pending.guid = guid;
+    pending.timer = std::max(0.0f, delaySeconds);
+    pending.remainingAttempts = std::max<uint8_t>(attempts, 1);
+    pendingGameObjectLootOpens_.push_back(pending);
+}
+
+void GameHandler::clearPendingGameObjectLootOpen(uint64_t guid) {
+    pendingGameObjectLootOpens_.erase(
+        std::remove_if(pendingGameObjectLootOpens_.begin(), pendingGameObjectLootOpens_.end(),
+                       [guid](const PendingLootOpen& pending) {
+                           return guid == 0 || pending.guid == guid;
+                       }),
+        pendingGameObjectLootOpens_.end());
+}
+
+bool GameHandler::hasPendingGameObjectLootOpen(uint64_t guid) const {
+    if (guid == 0) return false;
+    return std::any_of(pendingGameObjectLootOpens_.begin(), pendingGameObjectLootOpens_.end(),
+                       [guid](const PendingLootOpen& pending) {
+                           return pending.guid == guid;
+                       });
+}
+
+bool GameHandler::isGatherGameObject(uint64_t guid) const {
+    if (guid == 0 || !entityController_) return false;
+    auto entity = entityController_->getEntityManager().getEntity(guid);
+    if (!entity || entity->getType() != ObjectType::GAMEOBJECT) return false;
+
+    auto go = std::static_pointer_cast<GameObject>(entity);
+    const GameObjectQueryResponseData* goInfo = getCachedGameObjectInfo(go->getEntry());
+    return gatherSpellForGameObject(goInfo, go->getName()) != 0;
+}
+
+void GameHandler::despawnGameObjectLocally(uint64_t guid) {
+    if (guid == 0 || !entityController_) return;
+
+    auto& entityManager = entityController_->getEntityManager();
+    auto entity = entityManager.getEntity(guid);
+    if (!entity || entity->getType() != ObjectType::GAMEOBJECT) return;
+
+    if (gameObjectDespawnCallback_) gameObjectDespawnCallback_(guid);
+    entityManager.removeEntity(guid);
+
+    clearPendingGameObjectLootOpen(guid);
+    if (lastInteractedGoGuid_ == guid) lastInteractedGoGuid_ = 0;
+    if (pendingGameObjectInteractGuid_ == guid) pendingGameObjectInteractGuid_ = 0;
+    if (getTargetGuid() == guid) setTargetGuidRaw(0);
+    tabCycleStale = true;
+
+    LOG_INFO("Locally despawned game object: 0x", std::hex, guid, std::dec);
+}
+
 void GameHandler::lootMasterGive(uint8_t lootSlot, uint64_t targetGuid) {
     if (inventoryHandler_) inventoryHandler_->lootMasterGive(lootSlot, targetGuid);
 }
@@ -2008,17 +2129,17 @@ void GameHandler::performGameObjectInteractionNow(uint64_t guid) {
     uint32_t goEntry = 0;
     uint32_t goType = 0;
     std::string goName;
+    const GameObjectQueryResponseData* goInfo = nullptr;
 
     if (entity) {
         if (entity->getType() == ObjectType::GAMEOBJECT) {
             auto go = std::static_pointer_cast<GameObject>(entity);
             goEntry = go->getEntry();
             goName = go->getName();
-            if (auto* info = getCachedGameObjectInfo(goEntry)) goType = info->type;
+            goInfo = getCachedGameObjectInfo(goEntry);
+            if (goInfo) goType = goInfo->type;
             if (goType == 5 && !goName.empty()) {
-                std::string lower = goName;
-                std::transform(lower.begin(), lower.end(), lower.begin(),
-                               [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+                std::string lower = lowerCopy(goName);
                 if (lower.rfind("doodad_", 0) != 0) {
                     addSystemChatMessage(goName);
                 }
@@ -2057,17 +2178,15 @@ void GameHandler::performGameObjectInteractionNow(uint64_t guid) {
     bool chestLike = false;
     if (entity && entity->getType() == ObjectType::GAMEOBJECT) {
         auto go = std::static_pointer_cast<GameObject>(entity);
-        auto* info = getCachedGameObjectInfo(go->getEntry());
-        if (info && info->type == 19) {
+        if (!goInfo) goInfo = getCachedGameObjectInfo(go->getEntry());
+        if (goInfo && goInfo->type == 19) {
             isMailbox = true;
-        } else if (info && info->type == 3) {
+        } else if (goInfo && goInfo->type == 3) {
             chestLike = true;
         }
     }
     if (!chestLike && !goName.empty()) {
-        std::string lower = goName;
-        std::transform(lower.begin(), lower.end(), lower.begin(),
-                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        std::string lower = lowerCopy(goName);
         chestLike = (lower.find("chest") != std::string::npos ||
                      lower.find("lockbox") != std::string::npos ||
                      lower.find("strongbox") != std::string::npos ||
@@ -2080,6 +2199,26 @@ void GameHandler::performGameObjectInteractionNow(uint64_t guid) {
              " entry=", goEntry, " type=", goType,
              " name='", goName, "' chestLike=", chestLike, " isMailbox=", isMailbox);
 
+    const uint32_t gatherBaseSpellId = gatherSpellForGameObject(goInfo, goName);
+    if (gatherBaseSpellId != 0) {
+        const uint32_t gatherSpellId = knownGatherRank(spellHandler_.get(), gatherBaseSpellId);
+        if (gatherSpellId == 0) {
+            addSystemChatMessage(gatherBaseSpellId == 2575 ? "Requires Mining." : "Requires Herbalism.");
+            LOG_INFO("GO gather skipped: no known rank for base spell=", gatherBaseSpellId,
+                     " guid=0x", std::hex, guid, std::dec, " name='", goName, "'");
+            return;
+        }
+        auto castPacket = getPacketParsers()
+            ? getPacketParsers()->buildCastGameObjectSpell(gatherSpellId, guid, 0)
+            : CastSpellPacket::buildGameObjectTarget(gatherSpellId, guid, 0);
+        socket->send(castPacket);
+        lastInteractedGoGuid_ = guid;
+        scheduleGameObjectLootOpen(guid, 0.50f, 8);
+        LOG_INFO("GO gather cast: spell=", gatherSpellId, " guid=0x",
+                 std::hex, guid, std::dec, " name='", goName, "'");
+        return;
+    }
+
     // Always send CMSG_GAMEOBJ_USE first — this triggers the server-side
     // GameObject::Use() handler for all GO types.
     auto usePacket = GameObjectUsePacket::build(guid);
@@ -2091,9 +2230,10 @@ void GameHandler::performGameObjectInteractionNow(uint64_t guid) {
         // (e.g., "Opening") and the GO isn't lootable until the cast finishes.
         // Sending LOOT prematurely gets an empty response or is silently dropped,
         // which can interfere with the server's loot state machine.
-        // Instead, handleSpellGo will send LOOT after the cast completes
-        // (using lastInteractedGoGuid_ set above). For instant-open chests
-        // (no cast), the server sends SMSG_LOOT_RESPONSE directly after USE.
+        // Queue a delayed open: if a server-side gather cast starts, update()
+        // defers this until the cast is over; if no cast packet arrives, retry
+        // a few times so resource nodes do not fail after one early CMSG_LOOT.
+        scheduleGameObjectLootOpen(guid, 0.35f, 8);
     } else if (isMailbox) {
         openMailbox(guid);
     }

--- a/src/game/inventory_handler.cpp
+++ b/src/game/inventory_handler.cpp
@@ -698,13 +698,16 @@ void InventoryHandler::lootItem(uint8_t slotIndex) {
 
 void InventoryHandler::closeLoot() {
     if (!lootWindowOpen_) return;
+    const uint64_t lootGuid = currentLoot_.lootGuid;
+    const bool despawnGatherNode = owner_.isGatherGameObject(lootGuid);
     if (owner_.getState() == WorldState::IN_WORLD && owner_.getSocket()) {
-        auto packet = LootReleasePacket::build(currentLoot_.lootGuid);
+        auto packet = LootReleasePacket::build(lootGuid);
         owner_.getSocket()->send(packet);
     }
     lootWindowOpen_ = false;
     if (owner_.lootWindowCallbackRef()) owner_.lootWindowCallbackRef()(false);
     if (owner_.addonEventCallbackRef()) owner_.addonEventCallbackRef()("LOOT_CLOSED", {});
+    if (despawnGatherNode) owner_.despawnGameObjectLocally(lootGuid);
     currentLoot_ = LootResponseData{};
 }
 
@@ -723,8 +726,13 @@ void InventoryHandler::handleLootResponse(network::Packet& packet) {
     const bool hasLoot = !currentLoot_.items.empty() || currentLoot_.gold > 0;
     LOG_DEBUG("SMSG_LOOT_RESPONSE: guid=0x", std::hex, currentLoot_.lootGuid, std::dec,
               " items=", currentLoot_.items.size(), " gold=", currentLoot_.gold);
-    if (!hasLoot && owner_.isCasting() && owner_.getCurrentCastSpellId() != 0 && lastInteractedGoGuid_ != 0) {
-        LOG_DEBUG("Ignoring empty SMSG_LOOT_RESPONSE during gather cast");
+    auto& lastInteractedGoGuid = owner_.lastInteractedGoGuidRef();
+    const bool isLastInteractedGoLoot =
+        lastInteractedGoGuid != 0 && currentLoot_.lootGuid == lastInteractedGoGuid;
+    if (!hasLoot && isLastInteractedGoLoot &&
+        ((owner_.isCasting() && owner_.getCurrentCastSpellId() != 0) ||
+         owner_.hasPendingGameObjectLootOpen(currentLoot_.lootGuid))) {
+        LOG_DEBUG("Ignoring empty SMSG_LOOT_RESPONSE during pending gather/open");
         return;
     }
     lootWindowOpen_ = true;
@@ -733,11 +741,10 @@ void InventoryHandler::handleLootResponse(network::Packet& packet) {
         owner_.addonEventCallbackRef()("LOOT_OPENED", {});
         owner_.addonEventCallbackRef()("LOOT_READY", {});
     }
-    lastInteractedGoGuid_ = 0;
-    pendingGameObjectLootOpens_.erase(
-        std::remove_if(pendingGameObjectLootOpens_.begin(), pendingGameObjectLootOpens_.end(),
-                       [&](const PendingLootOpen& p) { return p.guid == currentLoot_.lootGuid; }),
-        pendingGameObjectLootOpens_.end());
+    if (currentLoot_.lootGuid == lastInteractedGoGuid) {
+        lastInteractedGoGuid = 0;
+    }
+    owner_.clearPendingGameObjectLootOpen(currentLoot_.lootGuid);
     auto& localLoot = localLootState_[currentLoot_.lootGuid];
     localLoot.data = currentLoot_;
 
@@ -772,10 +779,13 @@ void InventoryHandler::handleLootResponse(network::Packet& packet) {
 
 void InventoryHandler::handleLootReleaseResponse(network::Packet& packet) {
     (void)packet;
-    localLootState_.erase(currentLoot_.lootGuid);
+    const uint64_t lootGuid = currentLoot_.lootGuid;
+    const bool despawnGatherNode = owner_.isGatherGameObject(lootGuid);
+    localLootState_.erase(lootGuid);
     lootWindowOpen_ = false;
     if (owner_.lootWindowCallbackRef()) owner_.lootWindowCallbackRef()(false);
     if (owner_.addonEventCallbackRef()) owner_.addonEventCallbackRef()("LOOT_CLOSED", {});
+    if (despawnGatherNode) owner_.despawnGameObjectLocally(lootGuid);
     currentLoot_ = LootResponseData{};
 }
 

--- a/src/game/packet_parsers_classic.cpp
+++ b/src/game/packet_parsers_classic.cpp
@@ -426,6 +426,16 @@ network::Packet ClassicPacketParsers::buildCastSpell(uint32_t spellId, uint64_t 
     return packet;
 }
 
+network::Packet ClassicPacketParsers::buildCastGameObjectSpell(uint32_t spellId, uint64_t targetGuid, uint8_t /*castCount*/) {
+    network::Packet packet(wireOpcode(LogicalOpcode::CMSG_CAST_SPELL));
+    packet.writeUInt32(spellId);
+    packet.writeUInt16(0x0800); // TARGET_FLAG_GAMEOBJECT
+    packet.writePackedGuid(targetGuid);
+    LOG_DEBUG("[Classic] Built CMSG_CAST_SPELL: spell=", spellId, " gameObject=0x",
+              std::hex, targetGuid, std::dec, " size=", packet.getSize());
+    return packet;
+}
+
 // ============================================================================
 // Classic CMSG_USE_ITEM
 // Vanilla 1.12.x: bag(u8) + slot(u8) + spellIndex(u8) + SpellCastTargets(u16)

--- a/src/game/packet_parsers_tbc.cpp
+++ b/src/game/packet_parsers_tbc.cpp
@@ -742,6 +742,19 @@ network::Packet TbcPacketParsers::buildCastSpell(uint32_t spellId, uint64_t targ
     return packet;
 }
 
+network::Packet TbcPacketParsers::buildCastGameObjectSpell(uint32_t spellId, uint64_t targetGuid, uint8_t castCount) {
+    network::Packet packet(wireOpcode(LogicalOpcode::CMSG_CAST_SPELL));
+    packet.writeUInt32(spellId);
+    packet.writeUInt8(castCount);
+    // No castFlags byte in TBC 2.4.3
+    packet.writeUInt32(0x0800); // TARGET_FLAG_GAMEOBJECT
+    packet.writePackedGuid(targetGuid);
+    LOG_DEBUG("[TBC] Built CMSG_CAST_SPELL: spell=", spellId, " gameObject=0x",
+              std::hex, targetGuid, std::dec, " castCount=", static_cast<int>(castCount),
+              " size=", packet.getSize());
+    return packet;
+}
+
 // ============================================================================
 // TBC 2.4.3 CMSG_USE_ITEM
 // Format: bag(u8) + slot(u8) + spellIndex(u8) + castCount(u8) + itemGuid(u64)
@@ -1457,6 +1470,17 @@ static uint8_t translateTbcCastFailure(uint8_t tbcResult) {
     // TBC has no SUCCESS entry, while WoWee's shared string table is WotLK-based.
     // Most early values line up with +1.  Later enum sections diverge; map observed
     // high-value TBC failures explicitly so user-facing errors stay sane.
+    switch (tbcResult) {
+        case 0x17: return 25;  // SPELL_FAILED_CHEST_IN_USE
+        case 0x24: return 38;  // SPELL_FAILED_IMMUNE
+        case 0x25: return 40;  // SPELL_FAILED_INTERRUPTED
+        case 0x26: return 41;  // SPELL_FAILED_INTERRUPTED_COMBAT
+        case 0x2E: return 49;  // SPELL_FAILED_LOW_CASTLEVEL
+        case 0x7F: return 132; // SPELL_FAILED_TRY_AGAIN
+        case 0x91: return 146; // SPELL_FAILED_DAMAGE_IMMUNE
+        case 0x95: return 150; // SPELL_FAILED_MIN_SKILL
+        default: break;
+    }
     if (tbcResult == 63) return 67; // SPELL_FAILED_NOT_READY
     return static_cast<uint8_t>(tbcResult + 1);
 }

--- a/src/game/spell_handler.cpp
+++ b/src/game/spell_handler.cpp
@@ -38,6 +38,9 @@ constexpr uint32_t kItemClassConsumable = 0;
 constexpr uint32_t kConsumableSubclassBandage = 7;
 constexpr uint32_t kConsumableSubclassItemEnhancement = 6;
 constexpr uint8_t kSpellFailedNotReady = 67;
+constexpr uint8_t kSpellFailedAlreadyOpen = 8;
+constexpr uint8_t kSpellFailedChestInUse = 25;
+constexpr uint8_t kSpellFailedTryAgain = 132;
 
 bool isBandageItem(const ItemQueryResponseData* info) {
     return info && info->valid &&
@@ -52,6 +55,27 @@ uint64_t targetGuidForUseItem(GameHandler& owner, const ItemQueryResponseData* i
     }
     if (info->subClass == kConsumableSubclassItemEnhancement) return 0;
     return owner.getPlayerGuid();
+}
+
+bool isGatherSpellId(uint32_t spellId) {
+    static constexpr uint32_t kGatherRanks[] = {
+        2575, 2576, 3564, 10248, 29354, // Mining
+        2366, 2368, 3570, 11993, 28695  // Herbalism
+    };
+    for (uint32_t rankSpellId : kGatherRanks) {
+        if (spellId == rankSpellId) return true;
+    }
+    return false;
+}
+
+bool shouldDespawnGatherTarget(uint8_t result) {
+    return result == kSpellFailedAlreadyOpen || result == kSpellFailedChestInUse;
+}
+
+std::string gatherCastFailureMessage(uint8_t result, const std::string& fallback) {
+    if (result == kSpellFailedTryAgain) return "Failed.";
+    if (result == kSpellFailedChestInUse) return "Already in use.";
+    return fallback;
 }
 } // namespace
 
@@ -986,6 +1010,9 @@ void SpellHandler::handleCastFailed(network::Packet& packet) {
                                     : CastFailedParser::parse(packet, data);
     if (!ok) return;
 
+    const uint64_t gatherGoGuid = owner_.lastInteractedGoGuidRef();
+    const bool gatherCast = gatherGoGuid != 0 && isGatherSpellId(data.spellId);
+
     casting_ = false;
     castIsChannel_ = false;
     currentCastSpellId_ = 0;
@@ -1021,6 +1048,12 @@ void SpellHandler::handleCastFailed(network::Packet& packet) {
     const char* reason = getSpellCastResultString(data.result, powerType);
     std::string errMsg = reason ? reason
                                 : ("Spell cast failed (error " + std::to_string(data.result) + ")");
+    if (gatherCast) {
+        errMsg = gatherCastFailureMessage(data.result, errMsg);
+        if (shouldDespawnGatherTarget(data.result)) {
+            owner_.despawnGameObjectLocally(gatherGoGuid);
+        }
+    }
     owner_.addUIError(errMsg);
     MessageChatData msg;
     msg.type = ChatType::SYSTEM;
@@ -1200,7 +1233,6 @@ void SpellHandler::handleSpellGo(network::Packet& packet) {
             LOG_DEBUG("[GO-DIAG] Sending CMSG_LOOT for GO 0x", std::hex,
                         owner_.lastInteractedGoGuidRef(), std::dec);
             owner_.lootTarget(owner_.lastInteractedGoGuidRef());
-            owner_.lastInteractedGoGuidRef() = 0;
         }
         // Clear the GO interaction guard so future cancelCast() calls work
         // normally. Without this, pendingGameObjectInteractGuid_ stays stale
@@ -2379,8 +2411,11 @@ void SpellHandler::handleCastResult(network::Packet& packet) {
     if (owner_.getPacketParsers()->parseCastResult(packet, castResultSpellId, castResult)) {
         LOG_DEBUG("SMSG_CAST_RESULT: spellId=", castResultSpellId, " result=", static_cast<int>(castResult));
         if (castResult != 0) {
+            const uint64_t gatherGoGuid = owner_.lastInteractedGoGuidRef();
+            const bool gatherCast = gatherGoGuid != 0 && isGatherSpellId(castResultSpellId);
             casting_ = false; castIsChannel_ = false; currentCastSpellId_ = 0; castTimeRemaining_ = 0.0f;
             owner_.lastInteractedGoGuidRef() = 0;
+            owner_.pendingGameObjectInteractGuidRef() = 0;
             craftQueueSpellId_ = 0; craftQueueRemaining_ = 0;
             queuedSpellId_ = 0; queuedSpellTarget_ = 0;
             int playerPowerType = -1;
@@ -2394,6 +2429,12 @@ void SpellHandler::handleCastResult(network::Packet& packet) {
             }
             std::string errMsg = reason ? reason
                                         : ("Spell cast failed (error " + std::to_string(castResult) + ")");
+            if (gatherCast) {
+                errMsg = gatherCastFailureMessage(castResult, errMsg);
+                if (shouldDespawnGatherTarget(castResult)) {
+                    owner_.despawnGameObjectLocally(gatherGoGuid);
+                }
+            }
             owner_.addUIError(errMsg);
             if (owner_.spellCastFailedCallbackRef()) owner_.spellCastFailedCallbackRef()(castResultSpellId);
                 owner_.fireAddonEvent("UNIT_SPELLCAST_FAILED", {"player", std::to_string(castResultSpellId)});

--- a/src/game/world_packets_entity.cpp
+++ b/src/game/world_packets_entity.cpp
@@ -1062,6 +1062,19 @@ network::Packet CastSpellPacket::build(uint32_t spellId, uint64_t targetGuid, ui
     return packet;
 }
 
+network::Packet CastSpellPacket::buildGameObjectTarget(uint32_t spellId, uint64_t targetGuid, uint8_t castCount) {
+    network::Packet packet(wireOpcode(Opcode::CMSG_CAST_SPELL));
+    packet.writeUInt8(castCount);
+    packet.writeUInt32(spellId);
+    packet.writeUInt8(0x00); // castFlags = 0 for normal cast
+    packet.writeUInt32(0x0800); // TARGET_FLAG_GAMEOBJECT
+    packet.writePackedGuid(targetGuid);
+
+    LOG_DEBUG("Built CMSG_CAST_SPELL: spell=", spellId, " gameObject=0x",
+              std::hex, targetGuid, std::dec);
+    return packet;
+}
+
 network::Packet CancelAuraPacket::build(uint32_t spellId) {
     network::Packet packet(wireOpcode(Opcode::CMSG_CANCEL_AURA));
     packet.writeUInt32(spellId);

--- a/src/ui/game_screen.cpp
+++ b/src/ui/game_screen.cpp
@@ -1193,7 +1193,9 @@ void GameScreen::processTargetInput(game::GameHandler& gameHandler) {
                     hitCenter = core::coords::canonicalToRender(glm::vec3(entity->getX(), entity->getY(), entity->getZ()));
                     hitCenter.z += isGo ? 1.2f : 1.0f;
                 } else {
-                    hitRadius = std::max(hitRadius * 1.25f, 1.0f);
+                    // Resource nodes can have very tight render bounds; keep
+                    // their click target close to the no-bounds fallback.
+                    hitRadius = std::max(hitRadius * 1.25f, isGo ? 2.5f : 1.0f);
                 }
 
                 float hitT;
@@ -1270,7 +1272,9 @@ void GameScreen::processTargetInput(game::GameHandler& gameHandler) {
                         hitCenter = core::coords::canonicalToRender(glm::vec3(entity->getX(), entity->getY(), entity->getZ()));
                         hitCenter.z += heightOffset;
                     } else {
-                        hitRadius = std::max(hitRadius * 1.25f, 1.0f);
+                        hitRadius = std::max(
+                            hitRadius * 1.25f,
+                            t == game::ObjectType::GAMEOBJECT ? 2.5f : 1.0f);
                     }
 
                     float hitT;
@@ -1413,7 +1417,9 @@ void GameScreen::processTargetInput(game::GameHandler& gameHandler) {
                             }
                         }
                     } else {
-                        hitRadius = std::max(hitRadius * 1.25f, 1.0f);
+                        hitRadius = std::max(
+                            hitRadius * 1.25f,
+                            t == game::ObjectType::GAMEOBJECT ? 2.5f : 1.0f);
                     }
 
                     float hitT;


### PR DESCRIPTION
## Summary

Improves TBC gathering/resource-node interaction, especially mining nodes on CMaNGOS:

- Adds GO-targeted `CMSG_CAST_SPELL` builders for Classic/TBC/shared packet parsers.
- Detects mining/herbalism game objects and casts the best known gathering rank.
- Retries delayed loot opens so resource nodes do not fail after one early empty loot response.
- Ignores empty loot responses while gathering/opening is still pending.
- Locally despawns gathered nodes after loot close/release or relevant cast failure.
- Maps observed TBC cast failure codes to clearer shared failure messages.
- Increases game object click radius fallback for easier resource-node targeting.

## Testing

- Built successfully with `cmake --build build --target wowee -j 2`.
- Playtested mining interaction against TBC/CMaNGOS resource nodes.