### PR TITLE
fix(tbc): render visible equipment for inspected players

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ imgui.ini
 # Config files
 config.ini
 config.json
+.env
 
 # Runtime cache (floor heights, etc.)
 cache/

--- a/include/game/game_handler.hpp
+++ b/include/game/game_handler.hpp
@@ -2472,6 +2472,7 @@ public:
     void rebuildOnlineInventory();
     void maybeDetectVisibleItemLayout();
     void updateOtherPlayerVisibleItems(uint64_t guid, const FlatFieldMap& fields);
+    void cacheInspectedPlayerEquipment(uint64_t guid, const std::array<uint32_t, 19>& itemEntries);
     void detectInventorySlotBases(const FlatFieldMap& fields);
     bool applyInventoryFields(const FlatFieldMap& fields);
     void extractContainerFields(uint64_t containerGuid, const FlatFieldMap& fields);

--- a/include/game/game_handler.hpp
+++ b/include/game/game_handler.hpp
@@ -430,8 +430,10 @@ public:
 
     using InspectArenaTeam = game::InspectArenaTeam;
     using InspectResult = game::InspectResult;
-    const InspectResult* getInspectResult() const {
-        return inspectResult_.guid ? &inspectResult_ : nullptr;
+    const InspectResult* getInspectResult() const;
+    const std::array<uint32_t, 19>* getOtherPlayerVisibleEquipment(uint64_t guid) const {
+        auto it = otherPlayerVisibleItemEntries_.find(guid);
+        return (it != otherPlayerVisibleItemEntries_.end()) ? &it->second : nullptr;
     }
 
     // Server info commands

--- a/include/game/handler_types.hpp
+++ b/include/game/handler_types.hpp
@@ -88,6 +88,9 @@ struct InspectResult {
     std::string playerName;
     uint32_t    totalTalents   = 0;
     uint32_t    unspentTalents = 0;
+    bool        hasTalentData  = false;
+    bool        hasTalentTreePoints = false;
+    std::array<uint32_t, 3> talentTreePoints{};
     uint8_t     talentGroups   = 0;
     uint8_t     activeTalentGroup = 0;
     std::array<uint32_t, 19> itemEntries{};

--- a/include/game/inventory_handler.hpp
+++ b/include/game/inventory_handler.hpp
@@ -241,6 +241,7 @@ public:
     void rebuildOnlineInventory();
     void maybeDetectVisibleItemLayout();
     void updateOtherPlayerVisibleItems(uint64_t guid, const FlatFieldMap& fields);
+    void cacheInspectedPlayerEquipment(uint64_t guid, const std::array<uint32_t, 19>& itemEntries);
     void emitOtherPlayerEquipment(uint64_t guid);
     void emitAllOtherPlayerEquipment();
     void handleItemQueryResponse(network::Packet& packet);

--- a/include/ui/social_panel.hpp
+++ b/include/ui/social_panel.hpp
@@ -78,6 +78,7 @@ public:
 
 private:
     UIServices services_;
+    uint64_t inspectWindowAutoRequestGuid_ = 0;
 };
 
 } // namespace ui

--- a/src/core/entity_spawner_player.cpp
+++ b/src/core/entity_spawner_player.cpp
@@ -304,7 +304,7 @@ void EntitySpawner::spawnOnlinePlayer(uint64_t guid,
     activeGeosets.insert(kGeosetBareSleeves);
     activeGeosets.insert(kGeosetDefaultKneepads);
     activeGeosets.insert(kGeosetBarePants);
-    activeGeosets.insert(kGeosetWithCape);
+    activeGeosets.insert(kGeosetNoCape);
     activeGeosets.insert(kGeosetBareFeet);
     charRenderer->setActiveGeosets(instanceId, activeGeosets);
 
@@ -416,41 +416,64 @@ void EntitySpawner::setOnlinePlayerEquipment(uint64_t guid,
     const uint32_t geosetGroup1Field = idiL ? (*idiL)["GeosetGroup1"] : 7;
     const uint32_t geosetGroup3Field = idiL ? (*idiL)["GeosetGroup3"] : 9;
 
+    std::unordered_set<uint16_t> modelGeosets;
+    if (const auto* modelData = charRenderer->getModelData(st.modelId)) {
+        for (const auto& batch : modelData->batches) {
+            modelGeosets.insert(batch.submeshId);
+        }
+    }
+
+    auto eraseGroup = [&](uint16_t group) {
+        for (auto it = geosets.begin(); it != geosets.end();) {
+            if ((*it / 100) == group) {
+                it = geosets.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    };
+
+    auto pickGeoset = [&](uint16_t preferred, uint16_t fallback) -> uint16_t {
+        if (preferred != 0 && modelGeosets.count(preferred) > 0) return preferred;
+        if (fallback != 0 && modelGeosets.count(fallback) > 0) return fallback;
+        return 0;
+    };
+
     // Per-group defaults — overridden below when equipment provides a geoset value.
-    uint16_t geosetGloves  = kGeosetBareForearms;
-    uint16_t geosetBoots   = kGeosetBareShins;
-    uint16_t geosetSleeves = kGeosetBareSleeves;
-    uint16_t geosetPants   = kGeosetBarePants;
+    uint16_t geosetGloves  = pickGeoset(kGeosetBareForearms, kGeosetBareForearms);
+    uint16_t geosetBoots   = pickGeoset(kGeosetBareShins, kGeosetBareShins);
+    uint16_t geosetSleeves = pickGeoset(kGeosetBareSleeves, kGeosetBareSleeves);
+    uint16_t geosetPants   = pickGeoset(kGeosetBarePants, kGeosetBarePants);
 
     // Chest/Shirt/Robe (invType 4,5,20) → wrist/sleeve group 8
     {
         uint32_t did = findDisplayIdByInvType({4, 5, 20});
         uint32_t gg1 = getGeosetGroup(did, geosetGroup1Field);
-        if (gg1 > 0) geosetSleeves = static_cast<uint16_t>(kGeosetBareSleeves + gg1);
+        if (gg1 > 0) geosetSleeves = pickGeoset(static_cast<uint16_t>(kGeosetBareSleeves + gg1), kGeosetBareSleeves);
         // Robe kilt → leg group 13
         uint32_t gg3 = getGeosetGroup(did, geosetGroup3Field);
-        if (gg3 > 0) geosetPants = static_cast<uint16_t>(kGeosetBarePants + gg3);
+        if (gg3 > 0) geosetPants = pickGeoset(static_cast<uint16_t>(kGeosetBarePants + gg3), kGeosetBarePants);
     }
 
     // Legs (invType 7) → leg group 13
     {
         uint32_t did = findDisplayIdByInvType({7});
         uint32_t gg1 = getGeosetGroup(did, geosetGroup1Field);
-        if (gg1 > 0) geosetPants = static_cast<uint16_t>(kGeosetBarePants + gg1);
+        if (gg1 > 0) geosetPants = pickGeoset(static_cast<uint16_t>(kGeosetBarePants + gg1), kGeosetBarePants);
     }
 
     // Feet/Boots (invType 8) → shin group 5
     {
         uint32_t did = findDisplayIdByInvType({8});
         uint32_t gg1 = getGeosetGroup(did, geosetGroup1Field);
-        if (gg1 > 0) geosetBoots = static_cast<uint16_t>(501 + gg1);
+        if (gg1 > 0) geosetBoots = pickGeoset(static_cast<uint16_t>(501 + gg1), kGeosetBareShins);
     }
 
     // Hands/Gloves (invType 10) → forearm group 4
     {
         uint32_t did = findDisplayIdByInvType({10});
         uint32_t gg1 = getGeosetGroup(did, geosetGroup1Field);
-        if (gg1 > 0) geosetGloves = static_cast<uint16_t>(kGeosetBareForearms + gg1);
+        if (gg1 > 0) geosetGloves = pickGeoset(static_cast<uint16_t>(kGeosetBareForearms + gg1), kGeosetBareForearms);
     }
 
     // Wrists/Bracers (invType 9) → sleeve group 8 (only if chest/shirt didn't set it)
@@ -458,7 +481,7 @@ void EntitySpawner::setOnlinePlayerEquipment(uint64_t guid,
         uint32_t did = findDisplayIdByInvType({9});
         if (did != 0 && geosetSleeves == kGeosetBareSleeves) {
             uint32_t gg1 = getGeosetGroup(did, geosetGroup1Field);
-            if (gg1 > 0) geosetSleeves = static_cast<uint16_t>(kGeosetBareSleeves + gg1);
+            if (gg1 > 0) geosetSleeves = pickGeoset(static_cast<uint16_t>(kGeosetBareSleeves + gg1), kGeosetBareSleeves);
         }
     }
 
@@ -467,16 +490,25 @@ void EntitySpawner::setOnlinePlayerEquipment(uint64_t guid,
     {
         uint32_t did = findDisplayIdByInvType({6});
         uint32_t gg1 = getGeosetGroup(did, geosetGroup1Field);
-        if (gg1 > 0) geosetBelt = static_cast<uint16_t>(1801 + gg1);
+        if (gg1 > 0) geosetBelt = pickGeoset(static_cast<uint16_t>(1801 + gg1), 0);
     }
 
-    geosets.insert(geosetGloves);
-    geosets.insert(geosetBoots);
-    geosets.insert(geosetSleeves);
-    geosets.insert(geosetPants);
+    eraseGroup(4);
+    eraseGroup(5);
+    eraseGroup(8);
+    eraseGroup(13);
+    eraseGroup(15);
+    eraseGroup(18);
+    if (geosetGloves != 0) geosets.insert(geosetGloves);
+    if (geosetBoots != 0) geosets.insert(geosetBoots);
+    if (geosetSleeves != 0) geosets.insert(geosetSleeves);
+    if (geosetPants != 0) geosets.insert(geosetPants);
     if (geosetBelt != 0) geosets.insert(geosetBelt);
     // Back/Cloak (invType 16)
-    geosets.insert(hasInvType({16}) ? kGeosetWithCape : kGeosetNoCape);
+    uint16_t geosetCape = pickGeoset(
+        hasInvType({16}) ? kGeosetWithCape : kGeosetNoCape,
+        kGeosetNoCape);
+    if (geosetCape != 0) geosets.insert(geosetCape);
     // Tabard (invType 19)
     if (hasInvType({19})) geosets.insert(kGeosetDefaultTabard);
 

--- a/src/game/game_handler_callbacks.cpp
+++ b/src/game/game_handler_callbacks.cpp
@@ -1298,6 +1298,10 @@ void GameHandler::inspectTarget() {
     if (socialHandler_) socialHandler_->inspectTarget();
 }
 
+const GameHandler::InspectResult* GameHandler::getInspectResult() const {
+    return socialHandler_ ? socialHandler_->getInspectResult() : nullptr;
+}
+
 void GameHandler::queryServerTime() {
     if (socialHandler_) socialHandler_->queryServerTime();
 }

--- a/src/game/game_handler_callbacks.cpp
+++ b/src/game/game_handler_callbacks.cpp
@@ -1606,6 +1606,10 @@ void GameHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFieldMa
     if (inventoryHandler_) inventoryHandler_->updateOtherPlayerVisibleItems(guid, fields);
 }
 
+void GameHandler::cacheInspectedPlayerEquipment(uint64_t guid, const std::array<uint32_t, 19>& itemEntries) {
+    if (inventoryHandler_) inventoryHandler_->cacheInspectedPlayerEquipment(guid, itemEntries);
+}
+
 void GameHandler::emitOtherPlayerEquipment(uint64_t guid) {
     if (inventoryHandler_) inventoryHandler_->emitOtherPlayerEquipment(guid);
 }

--- a/src/game/game_handler_packets.cpp
+++ b/src/game/game_handler_packets.cpp
@@ -1940,13 +1940,7 @@ void GameHandler::registerOpcodeHandlers() {
             ir.enchantIds     = {};
         }
 
-        // Also cache for future talent-inspect cross-reference
-        inspectedPlayerItemEntries_[guid] = items;
-
-        // Trigger item queries for non-empty slots
-        for (int s = 0; s < kGearSlots; ++s) {
-            if (items[s] != 0) queryItemInfo(items[s], 0);
-        }
+        cacheInspectedPlayerEquipment(guid, items);
 
         LOG_INFO("SMSG_INSPECT (Classic): ", playerName, " has gear in ",
                  std::count_if(items.begin(), items.end(),

--- a/src/game/inventory_handler.cpp
+++ b/src/game/inventory_handler.cpp
@@ -16,6 +16,7 @@
 #include <algorithm>
 #include <cmath>
 #include <chrono>
+#include <cstdlib>
 #include <sstream>
 
 namespace wowee {
@@ -38,7 +39,31 @@ bool isBandageItem(const ItemQueryResponseData* info) {
 }
 
 bool usesVisibleItemDisplayIds() {
-    return isActiveExpansion("tbc");
+    return false;
+}
+
+constexpr int kTbcVisibleItemStride = 16;
+
+int tbcVisibleItemBaseFallback() {
+    const uint16_t invSlotHead = fieldIndex(UF::PLAYER_FIELD_INV_SLOT_HEAD);
+    constexpr int kVisibleSlots = 19;
+    const int visibleBytes = kVisibleSlots * kTbcVisibleItemStride;
+    if (invSlotHead != 0xFFFF && invSlotHead >= visibleBytes) {
+        return static_cast<int>(invSlotHead) - visibleBytes;
+    }
+    return 346;
+}
+
+bool visibleEquipmentFieldDiagEnabled() {
+    static const bool enabled = [] {
+        const char* raw = std::getenv("WOWEE_VISIBLE_EQUIP_FIELD_DIAG");
+        if (!raw || raw[0] == '\0') return false;
+        std::string value(raw);
+        std::transform(value.begin(), value.end(), value.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return value != "0" && value != "false" && value != "off";
+    }();
+    return enabled;
 }
 
 std::array<uint8_t, 19> inferredVisibleInventoryTypes() {
@@ -3132,21 +3157,112 @@ void InventoryHandler::rebuildOnlineInventory() {
 void InventoryHandler::maybeDetectVisibleItemLayout() {
     if (owner_.visibleItemLayoutVerifiedRef()) return;
     if (usesVisibleItemDisplayIds()) {
-        owner_.visibleItemEntryBaseRef() = 272;
-        owner_.visibleItemStrideRef() = 4;
-        owner_.visibleItemLayoutVerifiedRef() = true;
-        LOG_INFO("Using TBC PLAYER_VISIBLE_ITEM display layout: base=",
-                 owner_.visibleItemEntryBaseRef(), " stride=",
-                 owner_.visibleItemStrideRef());
+        std::array<uint32_t, 19> equipDisplayIds = owner_.lastEquipDisplayIdsRef();
+        int nonZero = 0;
+        for (int i = 0; i < 19; ++i) {
+            if (equipDisplayIds[i] == 0) {
+                const auto& slot = owner_.inventoryRef().getEquipSlot(static_cast<EquipSlot>(i));
+                if (!slot.empty()) equipDisplayIds[i] = slot.item.displayInfoId;
+            }
+            if (equipDisplayIds[i] != 0) nonZero++;
+        }
 
-        for (const auto& [guid, ent] : owner_.getEntityManager().getEntities()) {
-            if (!ent || ent->getType() != ObjectType::PLAYER) continue;
-            if (guid == owner_.getPlayerGuid()) continue;
-            updateOtherPlayerVisibleItems(guid, ent->getFields());
+        int bestBase = -1;
+        int bestStride = 0;
+        int bestMatches = 0;
+        int bestMismatches = 9999;
+        int bestScore = -999999;
+
+        if (nonZero >= 2 && !owner_.lastPlayerFieldsRef().empty()) {
+            const uint16_t maxKey = owner_.lastPlayerFieldsRef().back().first;
+            const int strides[] = {16, 12, 8, 4, 2, 3, 1};
+            for (int stride : strides) {
+                for (const auto& [baseIdxU16, _v] : owner_.lastPlayerFieldsRef()) {
+                    const int base = static_cast<int>(baseIdxU16);
+                    if (base + 18 * stride > static_cast<int>(maxKey)) continue;
+
+                    int matches = 0;
+                    int mismatches = 0;
+                    for (int s = 0; s < 19; ++s) {
+                        uint32_t want = equipDisplayIds[s];
+                        if (want == 0) continue;
+                        const uint16_t idx = static_cast<uint16_t>(base + s * stride);
+                        auto it = owner_.lastPlayerFieldsRef().find(idx);
+                        if (it == owner_.lastPlayerFieldsRef().end()) continue;
+                        if (it->second == want) {
+                            matches++;
+                        } else if (it->second != 0) {
+                            mismatches++;
+                        }
+                    }
+
+                    int score = matches * 3 - mismatches * 2;
+                    if (score > bestScore ||
+                        (score == bestScore && matches > bestMatches) ||
+                        (score == bestScore && matches == bestMatches && mismatches < bestMismatches) ||
+                        (score == bestScore && matches == bestMatches && mismatches == bestMismatches &&
+                         (bestBase < 0 || base < bestBase))) {
+                        bestScore = score;
+                        bestMatches = matches;
+                        bestMismatches = mismatches;
+                        bestBase = base;
+                        bestStride = stride;
+                    }
+                }
+            }
+        }
+
+        bool changed = false;
+        if (bestMatches >= 2 && bestBase >= 0 && bestStride > 0 && bestMismatches <= 2) {
+            changed = owner_.visibleItemEntryBaseRef() != bestBase ||
+                      owner_.visibleItemStrideRef() != bestStride;
+            owner_.visibleItemEntryBaseRef() = bestBase;
+            owner_.visibleItemStrideRef() = bestStride;
+            owner_.visibleItemLayoutVerifiedRef() = true;
+            LOG_INFO("Detected TBC PLAYER_VISIBLE_ITEM display layout: base=", bestBase,
+                     " stride=", bestStride, " (matches=", bestMatches,
+                     " mismatches=", bestMismatches, " score=", bestScore, ")");
+        } else {
+            // TBC exposes display IDs rather than item entries, but private cores
+            // are not perfectly consistent about the base offset. Keep the known
+            // 2.4.x fallback active without marking it verified, so later local
+            // equipment updates can still detect a better layout.
+            const int kTbcFallbackBase = tbcVisibleItemBaseFallback();
+            constexpr int kTbcFallbackStride = kTbcVisibleItemStride;
+            changed = owner_.visibleItemEntryBaseRef() != kTbcFallbackBase ||
+                      owner_.visibleItemStrideRef() != kTbcFallbackStride;
+            owner_.visibleItemEntryBaseRef() = kTbcFallbackBase;
+            owner_.visibleItemStrideRef() = kTbcFallbackStride;
+            static bool loggedProvisionalLayout = false;
+            if (!loggedProvisionalLayout) {
+                loggedProvisionalLayout = true;
+                LOG_INFO("Using provisional TBC PLAYER_VISIBLE_ITEM display layout: base=",
+                         kTbcFallbackBase, " stride=", kTbcFallbackStride,
+                         " (waiting for local display-ID confirmation)");
+            }
+            if (visibleEquipmentFieldDiagEnabled()) {
+                LOG_INFO("TBC visible layout detection pending: localDisplayIds=", nonZero,
+                         " bestBase=", bestBase, " bestStride=", bestStride,
+                         " matches=", bestMatches, " mismatches=", bestMismatches,
+                         " score=", bestScore);
+            }
+        }
+
+        if (changed || owner_.visibleItemLayoutVerifiedRef()) {
+            for (const auto& [guid, ent] : owner_.getEntityManager().getEntities()) {
+                if (!ent || ent->getType() != ObjectType::PLAYER) continue;
+                if (guid == owner_.getPlayerGuid()) continue;
+                updateOtherPlayerVisibleItems(guid, ent->getFields());
+            }
         }
         return;
     }
     if (owner_.lastPlayerFieldsRef().empty()) return;
+
+    if (isActiveExpansion("tbc")) {
+        owner_.visibleItemEntryBaseRef() = tbcVisibleItemBaseFallback();
+        owner_.visibleItemStrideRef() = kTbcVisibleItemStride;
+    }
 
     std::array<uint32_t, 19> equipEntries{};
     int nonZero = 0;
@@ -3175,7 +3291,9 @@ void InventoryHandler::maybeDetectVisibleItemLayout() {
     int bestMismatches = 9999;
     int bestScore = -999999;
 
-    const int strides[] = {2, 3, 4, 1};
+    const std::array<int, 5> strides = isActiveExpansion("tbc")
+        ? std::array<int, 5>{16, 2, 3, 4, 1}
+        : std::array<int, 5>{2, 3, 4, 1, 16};
     for (int stride : strides) {
         for (const auto& [baseIdxU16, _v] : owner_.lastPlayerFieldsRef()) {
             const int base = static_cast<int>(baseIdxU16);
@@ -3237,14 +3355,15 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
     const bool valuesAreDisplayIds = usesVisibleItemDisplayIds();
     int base = owner_.visibleItemEntryBaseRef();
     int stride = owner_.visibleItemStrideRef();
-    if (valuesAreDisplayIds && !owner_.visibleItemLayoutVerifiedRef()) {
-        base = 272;
-        stride = 4;
-        owner_.visibleItemEntryBaseRef() = base;
-        owner_.visibleItemStrideRef() = stride;
-        owner_.visibleItemLayoutVerifiedRef() = true;
-        LOG_INFO("Using TBC PLAYER_VISIBLE_ITEM display layout: base=", base,
-                 " stride=", stride);
+    if (isActiveExpansion("tbc") && !owner_.visibleItemLayoutVerifiedRef()) {
+        const int kTbcFallbackBase = tbcVisibleItemBaseFallback();
+        constexpr int kTbcFallbackStride = kTbcVisibleItemStride;
+        if (base != kTbcFallbackBase || stride != kTbcFallbackStride) {
+            base = kTbcFallbackBase;
+            stride = kTbcFallbackStride;
+            owner_.visibleItemEntryBaseRef() = base;
+            owner_.visibleItemStrideRef() = stride;
+        }
     }
     if (base < 0 || stride <= 0) return; // Defensive: should never happen with defaults.
 
@@ -3284,6 +3403,27 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
             }
         }
         LOG_DEBUG("RAW FIELDS 270-340:", dump);
+    }
+    static int diagDumpCount = 0;
+    if (visibleEquipmentFieldDiagEnabled() && diagDumpCount < 8 && fields.size() > 20) {
+        diagDumpCount++;
+        std::ostringstream dump;
+        int emitted = 0;
+        uint16_t maxField = 0;
+        for (const auto& [idx, val] : fields) {
+            if (idx > maxField) maxField = idx;
+            if (idx < 220 || idx > 760 || val == 0) continue;
+            dump << " [" << idx << "]=" << val;
+            if (++emitted >= 180) {
+                dump << " ...";
+                break;
+            }
+        }
+        LOG_INFO("VISIBLE EQUIP FIELD DIAG guid=0x", std::hex, guid, std::dec,
+                 " fieldCount=", fields.size(), " maxField=", maxField,
+                 " base=", base, " stride=", stride,
+                 " verified=", owner_.visibleItemLayoutVerifiedRef(),
+                 " nonZero[220-760]=", dump.str());
     }
 
     if (nonZero > 0) {

--- a/src/game/inventory_handler.cpp
+++ b/src/game/inventory_handler.cpp
@@ -37,6 +37,34 @@ bool isBandageItem(const ItemQueryResponseData* info) {
            info->subClass == kConsumableSubclassBandage;
 }
 
+bool usesVisibleItemDisplayIds() {
+    return isActiveExpansion("tbc");
+}
+
+std::array<uint8_t, 19> inferredVisibleInventoryTypes() {
+    return {
+        InvType::HEAD,
+        InvType::NECK,
+        InvType::SHOULDERS,
+        InvType::SHIRT,
+        InvType::CHEST,
+        InvType::WAIST,
+        InvType::LEGS,
+        InvType::FEET,
+        InvType::WRISTS,
+        InvType::HANDS,
+        InvType::FINGER,
+        InvType::FINGER,
+        InvType::TRINKET,
+        InvType::TRINKET,
+        InvType::BACK,
+        InvType::MAIN_HAND,
+        InvType::SHIELD,
+        InvType::RANGED_BOW,
+        InvType::TABARD,
+    };
+}
+
 uint64_t targetGuidForUseItem(GameHandler& owner, const ItemQueryResponseData* info) {
     if (!info || !info->valid || info->itemClass != kItemClassConsumable) return 0;
     if (isBandageItem(info)) {
@@ -3103,6 +3131,21 @@ void InventoryHandler::rebuildOnlineInventory() {
 
 void InventoryHandler::maybeDetectVisibleItemLayout() {
     if (owner_.visibleItemLayoutVerifiedRef()) return;
+    if (usesVisibleItemDisplayIds()) {
+        owner_.visibleItemEntryBaseRef() = 272;
+        owner_.visibleItemStrideRef() = 4;
+        owner_.visibleItemLayoutVerifiedRef() = true;
+        LOG_INFO("Using TBC PLAYER_VISIBLE_ITEM display layout: base=",
+                 owner_.visibleItemEntryBaseRef(), " stride=",
+                 owner_.visibleItemStrideRef());
+
+        for (const auto& [guid, ent] : owner_.getEntityManager().getEntities()) {
+            if (!ent || ent->getType() != ObjectType::PLAYER) continue;
+            if (guid == owner_.getPlayerGuid()) continue;
+            updateOtherPlayerVisibleItems(guid, ent->getFields());
+        }
+        return;
+    }
     if (owner_.lastPlayerFieldsRef().empty()) return;
 
     std::array<uint32_t, 19> equipEntries{};
@@ -3191,8 +3234,18 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
     // Use the current base/stride (defaults are correct for WotLK 3.3.5a: base=284, stride=2).
     // The heuristic may refine these later, but we proceed immediately with whatever values
     // are set rather than waiting for verification.
-    const int base = owner_.visibleItemEntryBaseRef();
-    const int stride = owner_.visibleItemStrideRef();
+    const bool valuesAreDisplayIds = usesVisibleItemDisplayIds();
+    int base = owner_.visibleItemEntryBaseRef();
+    int stride = owner_.visibleItemStrideRef();
+    if (valuesAreDisplayIds && !owner_.visibleItemLayoutVerifiedRef()) {
+        base = 272;
+        stride = 4;
+        owner_.visibleItemEntryBaseRef() = base;
+        owner_.visibleItemStrideRef() = stride;
+        owner_.visibleItemLayoutVerifiedRef() = true;
+        LOG_INFO("Using TBC PLAYER_VISIBLE_ITEM display layout: base=", base,
+                 " stride=", stride);
+    }
     if (base < 0 || stride <= 0) return; // Defensive: should never happen with defaults.
 
     std::array<uint32_t, 19> newEntries{};
@@ -3223,6 +3276,7 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
     if (nonZero > 0) {
         LOG_DEBUG("updateOtherPlayerVisibleItems: guid=0x", std::hex, guid, std::dec,
                  " nonZero=", nonZero, " base=", base, " stride=", stride,
+                 " values=", (valuesAreDisplayIds ? "displayIds" : "itemEntries"),
                  " head=", newEntries[0], " shoulders=", newEntries[2],
                  " chest=", newEntries[4], " legs=", newEntries[6],
                  " mainhand=", newEntries[15], " offhand=", newEntries[16]);
@@ -3233,6 +3287,14 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
     if (old != newEntries) {
         old = newEntries;
         changed = true;
+    }
+
+    if (valuesAreDisplayIds) {
+        if (changed) {
+            owner_.otherPlayerVisibleDirtyRef().insert(guid);
+            emitOtherPlayerEquipment(guid);
+        }
+        return;
     }
 
     // Request item templates for any new visible entries.
@@ -3261,6 +3323,43 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
     }
 }
 
+void InventoryHandler::cacheInspectedPlayerEquipment(uint64_t guid, const std::array<uint32_t, 19>& itemEntries) {
+    if (guid == 0) return;
+
+    owner_.inspectedPlayerItemEntriesRef()[guid] = itemEntries;
+
+    std::array<uint32_t, 19> displayIds{};
+    std::array<uint8_t, 19> invTypes{};
+    int entries = 0;
+    int resolved = 0;
+
+    for (int s = 0; s < 19; ++s) {
+        const uint32_t entry = itemEntries[s];
+        if (entry == 0) continue;
+        entries++;
+
+        auto infoIt = owner_.itemInfoCacheRef().find(entry);
+        if (infoIt != owner_.itemInfoCacheRef().end()) {
+            displayIds[s] = infoIt->second.displayInfoId;
+            invTypes[s] = static_cast<uint8_t>(infoIt->second.inventoryType);
+            resolved++;
+            continue;
+        }
+
+        queryItemInfo(entry, 0);
+    }
+
+    LOG_DEBUG("cacheInspectedPlayerEquipment: guid=0x", std::hex, guid, std::dec,
+              " entries=", entries, " resolved=", resolved,
+              " head=", displayIds[0], " shoulders=", displayIds[2],
+              " chest=", displayIds[4], " legs=", displayIds[6],
+              " mainhand=", displayIds[15], " offhand=", displayIds[16]);
+
+    if (resolved > 0 && owner_.playerEquipmentCallbackRef()) {
+        owner_.playerEquipmentCallbackRef()(guid, displayIds, invTypes);
+    }
+}
+
 void InventoryHandler::emitOtherPlayerEquipment(uint64_t guid) {
     if (!owner_.playerEquipmentCallbackRef()) return;
     auto it = owner_.otherPlayerVisibleItemEntriesRef().find(guid);
@@ -3268,6 +3367,26 @@ void InventoryHandler::emitOtherPlayerEquipment(uint64_t guid) {
 
     std::array<uint32_t, 19> displayIds{};
     std::array<uint8_t, 19> invTypes{};
+    if (usesVisibleItemDisplayIds()) {
+        displayIds = it->second;
+        invTypes = inferredVisibleInventoryTypes();
+        int nonZeroDisplay = 0;
+        for (uint32_t displayId : displayIds) {
+            if (displayId != 0) nonZeroDisplay++;
+        }
+
+        LOG_DEBUG("emitOtherPlayerEquipment: guid=0x", std::hex, guid, std::dec,
+                 " TBC displayIds=", nonZeroDisplay,
+                 " head=", displayIds[0], " shoulders=", displayIds[2],
+                 " chest=", displayIds[4], " legs=", displayIds[6],
+                 " mainhand=", displayIds[15], " offhand=", displayIds[16]);
+
+        if (nonZeroDisplay == 0) return;
+        owner_.playerEquipmentCallbackRef()(guid, displayIds, invTypes);
+        owner_.otherPlayerVisibleDirtyRef().erase(guid);
+        return;
+    }
+
     bool anyEntry = false;
     int resolved = 0, unresolved = 0;
 

--- a/src/game/inventory_handler.cpp
+++ b/src/game/inventory_handler.cpp
@@ -3257,6 +3257,19 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
 
     int nonZero = 0;
     for (uint32_t e : newEntries) { if (e != 0) nonZero++; }
+    const bool hasVisibleBodySlot =
+        newEntries[2] != 0 ||  // shoulders
+        newEntries[4] != 0 ||  // chest
+        newEntries[6] != 0 ||  // legs
+        newEntries[7] != 0 ||  // feet
+        newEntries[9] != 0 ||  // hands
+        newEntries[15] != 0 || // main hand
+        newEntries[16] != 0;   // off hand
+    const bool sparseTbcVisible =
+        valuesAreDisplayIds &&
+        (nonZero == 0 || nonZero < 4 || (!hasVisibleBodySlot && nonZero < 8));
+    const bool hasInspectedEntries =
+        owner_.inspectedPlayerItemEntriesRef().find(guid) != owner_.inspectedPlayerItemEntriesRef().end();
 
     // Dump raw fields around visible item range to find the correct offset
     static int dumpCount = 0;
@@ -3282,6 +3295,19 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
                  " mainhand=", newEntries[15], " offhand=", newEntries[16]);
     }
 
+    if (sparseTbcVisible) {
+        if (!hasInspectedEntries && owner_.getSocket() && owner_.getState() == WorldState::IN_WORLD) {
+            owner_.pendingAutoInspectRef().insert(guid);
+            LOG_DEBUG("updateOtherPlayerVisibleItems: guid=0x", std::hex, guid, std::dec,
+                      " sparse TBC visible fields (nonZero=", nonZero,
+                      ", base=", base, ", stride=", stride,
+                      ") - queuing auto-inspect");
+        } else if (hasInspectedEntries) {
+            LOG_DEBUG("updateOtherPlayerVisibleItems: guid=0x", std::hex, guid, std::dec,
+                      " sparse TBC visible fields ignored; inspect gear already cached");
+        }
+    }
+
     bool changed = false;
     auto& old = owner_.otherPlayerVisibleItemEntriesRef()[guid];
     if (old != newEntries) {
@@ -3290,6 +3316,9 @@ void InventoryHandler::updateOtherPlayerVisibleItems(uint64_t guid, const FlatFi
     }
 
     if (valuesAreDisplayIds) {
+        if (sparseTbcVisible && hasInspectedEntries) {
+            return;
+        }
         if (changed) {
             owner_.otherPlayerVisibleDirtyRef().insert(guid);
             emitOtherPlayerEquipment(guid);

--- a/src/game/social_handler.cpp
+++ b/src/game/social_handler.cpp
@@ -93,7 +93,7 @@ static bool parseInspectEquipmentPayload(network::Packet& packet,
         return true;
     };
 
-    if (packet.getRemainingSize() == sizeof(uint64_t) + kGearBytes) {
+    if (packet.getRemainingSize() >= sizeof(uint64_t) + kGearBytes) {
         outGuid = packet.readUInt64();
         if (outGuid != 0 && readItems()) {
             return true;
@@ -104,7 +104,7 @@ static bool parseInspectEquipmentPayload(network::Packet& packet,
 
     if (packet.hasFullPackedGuid()) {
         outGuid = packet.readPackedGuid();
-        if (outGuid != 0 && packet.getRemainingSize() == kGearBytes && readItems()) {
+        if (outGuid != 0 && packet.getRemainingSize() >= kGearBytes && readItems()) {
             return true;
         }
     }
@@ -701,6 +701,8 @@ void SocialHandler::handleInspectResults(network::Packet& packet) {
             }
             return;
         }
+        LOG_DEBUG("SMSG_INSPECT_RESULTS_UPDATE (TBC gear): unrecognized payload size=",
+                  packet.getSize());
     }
 
     if (!packet.hasRemaining(1)) return;

--- a/src/game/social_handler.cpp
+++ b/src/game/social_handler.cpp
@@ -17,6 +17,7 @@
 #include <cmath>
 #include <filesystem>
 #include <fstream>
+#include <vector>
 
 namespace wowee {
 namespace game {
@@ -81,9 +82,84 @@ static const char* lfgTeleportDeniedString(uint8_t reason) {
 
 static bool parseInspectEquipmentPayload(network::Packet& packet,
                                          uint64_t& outGuid,
-                                         std::array<uint32_t, 19>& outItems) {
+                                         std::array<uint32_t, 19>& outItems,
+                                         std::array<uint16_t, 19>& outEnchants) {
     const size_t start = packet.getReadPos();
     constexpr size_t kGearBytes = 19 * sizeof(uint32_t);
+    constexpr uint32_t kEquipmentSlotMask = (1u << 19) - 1u;
+
+    auto reset = [&]() {
+        packet.setReadPos(start);
+        outGuid = 0;
+        outItems.fill(0);
+        outEnchants.fill(0);
+    };
+
+    auto countSlots = [](uint32_t mask) {
+        int count = 0;
+        for (int slot = 0; slot < 19; ++slot) {
+            if (mask & (1u << slot)) ++count;
+        }
+        return count;
+    };
+
+    auto parseMaskedItems = [&](const char* guidEncoding) -> bool {
+        if (!packet.hasRemaining(sizeof(uint32_t))) return false;
+        const uint32_t slotMask = packet.readUInt32();
+        if ((slotMask & ~kEquipmentSlotMask) != 0) return false;
+
+        const int slotCount = countSlots(slotMask);
+        if (slotCount <= 0) return false;
+
+        const size_t remaining = packet.getRemainingSize();
+        const size_t candidateRecordSizes[] = {24, 20, 16, 12, 8, 4};
+        size_t recordSize = 0;
+        for (size_t candidate : candidateRecordSizes) {
+            if (remaining == static_cast<size_t>(slotCount) * candidate) {
+                recordSize = candidate;
+                break;
+            }
+        }
+        if (recordSize == 0) {
+            // Some cores append a tiny trailer. Prefer the largest plausible
+            // record that fits cleanly, but do not consume packets that are
+            // clearly not the masked inspect format.
+            for (size_t candidate : candidateRecordSizes) {
+                const size_t needed = static_cast<size_t>(slotCount) * candidate;
+                if (remaining >= needed && remaining - needed <= 8) {
+                    recordSize = candidate;
+                    break;
+                }
+            }
+        }
+        if (recordSize < sizeof(uint32_t)) return false;
+
+        int nonZero = 0;
+        for (int slot = 0; slot < 19; ++slot) {
+            if ((slotMask & (1u << slot)) == 0) continue;
+            if (!packet.hasRemaining(recordSize)) return false;
+
+            const size_t recordStart = packet.getReadPos();
+            const uint32_t itemEntry = packet.readUInt32();
+            uint16_t enchantId = 0;
+            if (recordSize >= sizeof(uint32_t) + sizeof(uint16_t) &&
+                packet.hasRemaining(sizeof(uint16_t))) {
+                enchantId = packet.readUInt16();
+            }
+            packet.setReadPos(recordStart + recordSize);
+
+            outItems[slot] = itemEntry;
+            outEnchants[slot] = enchantId;
+            if (itemEntry != 0) ++nonZero;
+        }
+
+        if (nonZero == 0) return false;
+        LOG_INFO("SMSG_INSPECT_RESULTS_UPDATE masked gear: guidEncoding=", guidEncoding,
+                 " mask=0x", std::hex, slotMask, std::dec,
+                 " slots=", slotCount, " recordSize=", recordSize,
+                 " nonZero=", nonZero);
+        return true;
+    };
 
     auto readItems = [&]() -> bool {
         for (uint32_t& item : outItems) {
@@ -93,25 +169,202 @@ static bool parseInspectEquipmentPayload(network::Packet& packet,
         return true;
     };
 
+    reset();
+    if (packet.hasRemaining(sizeof(uint64_t))) {
+        outGuid = packet.readUInt64();
+        if (outGuid != 0 && parseMaskedItems("uint64")) {
+            return true;
+        }
+    }
+
+    reset();
+    if (packet.hasFullPackedGuid()) {
+        outGuid = packet.readPackedGuid();
+        if (outGuid != 0 && parseMaskedItems("packed")) {
+            return true;
+        }
+    }
+
+    reset();
     if (packet.getRemainingSize() >= sizeof(uint64_t) + kGearBytes) {
         outGuid = packet.readUInt64();
         if (outGuid != 0 && readItems()) {
+            LOG_INFO("SMSG_INSPECT_RESULTS_UPDATE flat gear: guidEncoding=uint64 slots=19");
             return true;
         }
-        packet.setReadPos(start);
-        outItems.fill(0);
     }
 
+    reset();
     if (packet.hasFullPackedGuid()) {
         outGuid = packet.readPackedGuid();
         if (outGuid != 0 && packet.getRemainingSize() >= kGearBytes && readItems()) {
+            LOG_INFO("SMSG_INSPECT_RESULTS_UPDATE flat gear: guidEncoding=packed slots=19");
             return true;
         }
     }
 
+    reset();
+    return false;
+}
+
+static bool isTbcInspectTalentBitSet(const std::vector<uint8_t>& bitfield, uint32_t bitIndex) {
+    const uint32_t slot = bitIndex / 7u;
+    const uint32_t offset = bitIndex % 7u;
+    return slot < bitfield.size() && (bitfield[slot] & (1u << offset)) != 0;
+}
+
+static bool decodeTbcInspectTalentBitfield(GameHandler& owner,
+                                           uint8_t classId,
+                                           const std::vector<uint8_t>& bitfield,
+                                           std::array<uint32_t, 3>& outTreePoints,
+                                           uint32_t& outSpentTalents) {
+    outTreePoints.fill(0);
+    outSpentTalents = 0;
+    if (classId == 0 || bitfield.empty()) return false;
+
+    owner.loadTalentDbc();
+
+    const uint32_t classMask = 1u << (classId - 1u);
+    std::vector<const TalentTabEntry*> classTabs;
+    for (const auto& [tabId, tab] : owner.getAllTalentTabs()) {
+        if (tab.classMask & classMask) {
+            classTabs.push_back(&tab);
+        }
+    }
+    std::sort(classTabs.begin(), classTabs.end(),
+              [](const auto* a, const auto* b) { return a->orderIndex < b->orderIndex; });
+    if (classTabs.empty()) return false;
+
+    uint32_t tabBitStart = 0;
+    for (size_t tabIndex = 0; tabIndex < classTabs.size() && tabIndex < outTreePoints.size(); ++tabIndex) {
+        std::vector<const TalentEntry*> talents;
+        for (const auto& [talentId, talent] : owner.getAllTalents()) {
+            if (talent.tabId == classTabs[tabIndex]->tabId && talent.maxRank > 0) {
+                talents.push_back(&talent);
+            }
+        }
+        std::sort(talents.begin(), talents.end(), [](const auto* a, const auto* b) {
+            if (a->row != b->row) return a->row < b->row;
+            if (a->column != b->column) return a->column < b->column;
+            return a->talentId < b->talentId;
+        });
+
+        uint32_t tabBits = 0;
+        for (const auto* talent : talents) {
+            uint8_t rank = 0;
+            for (uint8_t r = 1; r <= talent->maxRank; ++r) {
+                if (isTbcInspectTalentBitSet(bitfield, tabBitStart + tabBits + (r - 1u))) {
+                    rank = r;
+                }
+            }
+            outTreePoints[tabIndex] += rank;
+            outSpentTalents += rank;
+            tabBits += talent->maxRank;
+        }
+        tabBitStart += tabBits;
+    }
+
+    return true;
+}
+
+static bool parseTbcInspectTalentPayload(network::Packet& packet,
+                                         GameHandler& owner,
+                                         uint8_t classId,
+                                         uint32_t& outUnspentTalents,
+                                         uint32_t& outSpentTalents,
+                                         std::array<uint32_t, 3>& outTreePoints,
+                                         bool& outHasTreePoints) {
+    const size_t start = packet.getReadPos();
+    outUnspentTalents = 0;
+    outSpentTalents = 0;
+    outTreePoints.fill(0);
+    outHasTreePoints = false;
+
+    const size_t payloadSize = packet.getRemainingSize();
+    if (payloadSize < sizeof(uint32_t)) {
+        packet.setReadPos(start);
+        return false;
+    }
+
+    auto parseTalentRecords = [](network::Packet& p, size_t count) {
+        uint32_t spent = 0;
+        for (size_t i = 0; i < count; ++i) {
+            const uint32_t talentId = p.readUInt32();
+            const uint8_t rank = p.readUInt8();
+            if (talentId == 0) continue;
+            spent += static_cast<uint32_t>(rank) + 1u;
+        }
+        return spent;
+    };
+
+    const uint32_t firstValue = packet.readUInt32();
+
+    // TBC/CMaNGOS sends SMSG_INSPECT_TALENT as:
+    //   uint32 byteCount, byte[byteCount] compact talent bitfield.
+    // Older attempts treated byteCount (0x3d) as talent points; keep the
+    // fallback list-style parser below for other 2.x cores, but prefer this
+    // server-authored bitfield when the size lines up exactly.
+    if (firstValue > 0 && firstValue <= 256 && packet.getRemainingSize() == firstValue) {
+        std::vector<uint8_t> bitfield;
+        bitfield.reserve(firstValue);
+        for (uint32_t i = 0; i < firstValue; ++i) {
+            bitfield.push_back(packet.readUInt8());
+        }
+
+        outHasTreePoints = decodeTbcInspectTalentBitfield(owner, classId, bitfield, outTreePoints, outSpentTalents);
+        if (!outHasTreePoints) {
+            outSpentTalents = 0;
+        }
+        LOG_INFO("SMSG_INSPECT_TALENT (TBC): parsed cmangos bitfield bytes=", firstValue,
+                 " spent=", outSpentTalents,
+                 " trees=", outTreePoints[0], "/", outTreePoints[1], "/", outTreePoints[2],
+                 " class=", static_cast<int>(classId),
+                 " decoded=", (outHasTreePoints ? "yes" : "no"),
+                 " trailingBytes=", packet.getRemainingSize());
+        return true;
+    }
+
+    // The regular talents-info packet uses uint32 unspent + uint8 count.
+    // Accept that shape too so different 2.x cores still render something useful.
+    if (packet.hasRemaining(1)) {
+        const uint8_t nextByte = packet.readUInt8();
+        const size_t afterHeaderBytes = packet.getRemainingSize();
+
+        if (afterHeaderBytes > 0 && (afterHeaderBytes % 5u) == 0u) {
+            const size_t recordCount = afterHeaderBytes / 5u;
+            const uint32_t rankSpent = parseTalentRecords(packet, recordCount);
+            outUnspentTalents = 0;
+            outSpentTalents = firstValue != 0 ? firstValue : rankSpent;
+            LOG_INFO("SMSG_INSPECT_TALENT (TBC): parsed cmangos talents records=", recordCount,
+                     " spent=", outSpentTalents, " rankSpent=", rankSpent,
+                     " unk=", static_cast<int>(nextByte),
+                     " trailingBytes=", packet.getRemainingSize());
+            return true;
+        }
+
+        const uint8_t talentCount = nextByte;
+        if (packet.hasRemaining(static_cast<size_t>(talentCount) * 5u)) {
+            const uint32_t spentTalents = parseTalentRecords(packet, talentCount);
+            outUnspentTalents = firstValue;
+            outSpentTalents = spentTalents;
+            LOG_INFO("SMSG_INSPECT_TALENT (TBC): parsed talents count=", static_cast<int>(talentCount),
+                     " spent=", spentTalents, " unspent=", firstValue,
+                     " trailingBytes=", packet.getRemainingSize());
+            return true;
+        }
+    }
+
+    if ((payloadSize % 5u) == 0u) {
+        packet.setReadPos(start);
+        const size_t recordCount = payloadSize / 5u;
+        outSpentTalents = parseTalentRecords(packet, recordCount);
+        LOG_INFO("SMSG_INSPECT_TALENT (TBC): parsed bare talents records=", recordCount,
+                 " spent=", outSpentTalents,
+                 " trailingBytes=", packet.getRemainingSize());
+        return true;
+    }
+
     packet.setReadPos(start);
-    outGuid = 0;
-    outItems.fill(0);
     return false;
 }
 
@@ -681,7 +934,8 @@ void SocialHandler::handleInspectResults(network::Packet& packet) {
     if (isActiveExpansion("tbc") && packet.getOpcode() == wireOpcode(Opcode::SMSG_INSPECT_RESULTS_UPDATE)) {
         uint64_t guid = 0;
         std::array<uint32_t, 19> items{};
-        if (parseInspectEquipmentPayload(packet, guid, items)) {
+        std::array<uint16_t, 19> enchantIds{};
+        if (parseInspectEquipmentPayload(packet, guid, items, enchantIds)) {
             owner_.cacheInspectedPlayerEquipment(guid, items);
 
             auto entity = owner_.getEntityManager().getEntity(guid);
@@ -690,6 +944,17 @@ void SocialHandler::handleInspectResults(network::Packet& packet) {
                 auto player = std::dynamic_pointer_cast<Player>(entity);
                 if (player && !player->getName().empty()) playerName = player->getName();
             }
+
+            // TBC servers send inspected gear separately from talent data. Make the
+            // gear-only response visible to the Inspect window immediately while
+            // preserving talents if a matching talent response already arrived.
+            if (inspectResult_.guid != guid) {
+                inspectResult_ = InspectResult{};
+                inspectResult_.guid = guid;
+            }
+            inspectResult_.playerName = playerName;
+            inspectResult_.itemEntries = items;
+            inspectResult_.enchantIds = enchantIds;
 
             LOG_INFO("SMSG_INSPECT_RESULTS_UPDATE (TBC gear): ", playerName, " has gear in ",
                      std::count_if(items.begin(), items.end(),
@@ -703,6 +968,62 @@ void SocialHandler::handleInspectResults(network::Packet& packet) {
         }
         LOG_DEBUG("SMSG_INSPECT_RESULTS_UPDATE (TBC gear): unrecognized payload size=",
                   packet.getSize());
+    }
+
+    if (isActiveExpansion("tbc") &&
+        packet.getOpcode() == wireOpcode(Opcode::SMSG_INSPECT_TALENT)) {
+        if (!packet.hasFullPackedGuid()) return;
+        uint64_t guid = packet.readPackedGuid();
+        if (guid == 0) return;
+
+        auto entity = owner_.getEntityManager().getEntity(guid);
+        std::string playerName = "Target";
+        if (entity) {
+            auto player = std::dynamic_pointer_cast<Player>(entity);
+            if (player && !player->getName().empty()) playerName = player->getName();
+        }
+
+        if (inspectResult_.guid != guid) {
+            inspectResult_ = InspectResult{};
+            inspectResult_.guid = guid;
+        }
+        inspectResult_.playerName = playerName;
+
+        uint32_t unspentTalents = 0;
+        uint32_t spentTalents = 0;
+        std::array<uint32_t, 3> treePoints{};
+        bool hasTreePoints = false;
+        const uint8_t classId = owner_.lookupPlayerClass(guid);
+        const size_t talentPayloadStart = packet.getReadPos();
+        if (parseTbcInspectTalentPayload(packet, owner_, classId, unspentTalents, spentTalents,
+                                         treePoints, hasTreePoints)) {
+            inspectResult_.totalTalents = spentTalents;
+            inspectResult_.unspentTalents = unspentTalents;
+            inspectResult_.hasTalentData = true;
+            inspectResult_.hasTalentTreePoints = hasTreePoints;
+            inspectResult_.talentTreePoints = treePoints;
+            inspectResult_.talentGroups = 1;
+            inspectResult_.activeTalentGroup = 0;
+        } else {
+            packet.setReadPos(talentPayloadStart);
+            LOG_INFO("SMSG_INSPECT_TALENT (TBC): ", playerName,
+                     " unparsed payload bytes=", packet.getRemainingSize());
+        }
+
+        auto gearIt = owner_.inspectedPlayerItemEntriesRef().find(guid);
+        if (gearIt != owner_.inspectedPlayerItemEntriesRef().end()) {
+            inspectResult_.itemEntries = gearIt->second;
+        }
+
+        LOG_INFO("SMSG_INSPECT_TALENT (TBC): ", playerName,
+                 " gearCached=", (gearIt != owner_.inspectedPlayerItemEntriesRef().end() ? "yes" : "no"),
+                 " payload bytes remaining=", packet.getRemainingSize());
+        if (owner_.addonEventCallbackRef()) {
+            char guidBuf[32];
+            snprintf(guidBuf, sizeof(guidBuf), "0x%016llX", (unsigned long long)guid);
+            owner_.addonEventCallbackRef()("INSPECT_READY", {guidBuf});
+        }
+        return;
     }
 
     if (!packet.hasRemaining(1)) return;
@@ -823,6 +1144,9 @@ void SocialHandler::handleInspectResults(network::Packet& packet) {
     inspectResult_.playerName        = playerName;
     inspectResult_.totalTalents      = totalTalents;
     inspectResult_.unspentTalents    = unspentTalents;
+    inspectResult_.hasTalentData     = true;
+    inspectResult_.hasTalentTreePoints = false;
+    inspectResult_.talentTreePoints  = {};
     inspectResult_.talentGroups      = talentGroupCount;
     inspectResult_.activeTalentGroup = activeTalentGroup;
     inspectResult_.enchantIds        = enchantIds;

--- a/src/game/social_handler.cpp
+++ b/src/game/social_handler.cpp
@@ -79,6 +79,42 @@ static const char* lfgTeleportDeniedString(uint8_t reason) {
     }
 }
 
+static bool parseInspectEquipmentPayload(network::Packet& packet,
+                                         uint64_t& outGuid,
+                                         std::array<uint32_t, 19>& outItems) {
+    const size_t start = packet.getReadPos();
+    constexpr size_t kGearBytes = 19 * sizeof(uint32_t);
+
+    auto readItems = [&]() -> bool {
+        for (uint32_t& item : outItems) {
+            if (!packet.hasRemaining(sizeof(uint32_t))) return false;
+            item = packet.readUInt32();
+        }
+        return true;
+    };
+
+    if (packet.getRemainingSize() == sizeof(uint64_t) + kGearBytes) {
+        outGuid = packet.readUInt64();
+        if (outGuid != 0 && readItems()) {
+            return true;
+        }
+        packet.setReadPos(start);
+        outItems.fill(0);
+    }
+
+    if (packet.hasFullPackedGuid()) {
+        outGuid = packet.readPackedGuid();
+        if (outGuid != 0 && packet.getRemainingSize() == kGearBytes && readItems()) {
+            return true;
+        }
+    }
+
+    packet.setReadPos(start);
+    outGuid = 0;
+    outItems.fill(0);
+    return false;
+}
+
 static const std::string kEmptyString;
 
 SocialHandler::SocialHandler(GameHandler& owner)
@@ -642,6 +678,31 @@ void SocialHandler::inspectTarget() {
 }
 
 void SocialHandler::handleInspectResults(network::Packet& packet) {
+    if (isActiveExpansion("tbc") && packet.getOpcode() == wireOpcode(Opcode::SMSG_INSPECT_RESULTS_UPDATE)) {
+        uint64_t guid = 0;
+        std::array<uint32_t, 19> items{};
+        if (parseInspectEquipmentPayload(packet, guid, items)) {
+            owner_.cacheInspectedPlayerEquipment(guid, items);
+
+            auto entity = owner_.getEntityManager().getEntity(guid);
+            std::string playerName = "Target";
+            if (entity) {
+                auto player = std::dynamic_pointer_cast<Player>(entity);
+                if (player && !player->getName().empty()) playerName = player->getName();
+            }
+
+            LOG_INFO("SMSG_INSPECT_RESULTS_UPDATE (TBC gear): ", playerName, " has gear in ",
+                     std::count_if(items.begin(), items.end(),
+                                   [](uint32_t e) { return e != 0; }), "/19 slots");
+            if (owner_.addonEventCallbackRef()) {
+                char guidBuf[32];
+                snprintf(guidBuf, sizeof(guidBuf), "0x%016llX", (unsigned long long)guid);
+                owner_.addonEventCallbackRef()("INSPECT_READY", {guidBuf});
+            }
+            return;
+        }
+    }
+
     if (!packet.hasRemaining(1)) return;
     uint8_t talentType = packet.readUInt8();
 

--- a/src/game/world_packets_social.cpp
+++ b/src/game/world_packets_social.cpp
@@ -2,6 +2,7 @@
 #include "game/packet_parsers.hpp"
 #include "game/opcodes.hpp"
 #include "game/character.hpp"
+#include "game/game_utils.hpp"
 #include "auth/crypto.hpp"
 #include "core/logger.hpp"
 #include <algorithm>
@@ -404,7 +405,11 @@ network::Packet SetActiveMoverPacket::build(uint64_t guid) {
 
 network::Packet InspectPacket::build(uint64_t targetGuid) {
     network::Packet packet(wireOpcode(Opcode::CMSG_INSPECT));
-    packet.writePackedGuid(targetGuid);
+    if (isActiveExpansion("classic") || isActiveExpansion("tbc") || isActiveExpansion("turtle")) {
+        packet.writeUInt64(targetGuid);
+    } else {
+        packet.writePackedGuid(targetGuid);
+    }
     LOG_DEBUG("Built CMSG_INSPECT: target=0x", std::hex, targetGuid, std::dec);
     return packet;
 }

--- a/src/ui/social_panel.cpp
+++ b/src/ui/social_panel.cpp
@@ -14,6 +14,7 @@
 #include "core/logger.hpp"
 #include "rendering/renderer.hpp"
 #include "game/game_handler.hpp"
+#include "game/game_utils.hpp"
 #include "pipeline/asset_manager.hpp"
 #include "pipeline/dbc_layout.hpp"
 #include "ui/keybinding_manager.hpp"
@@ -21,6 +22,7 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdio>
 #include <string>
@@ -2396,7 +2398,10 @@ void SocialPanel::renderWhoWindow(game::GameHandler& gameHandler,
 
 void SocialPanel::renderInspectWindow(game::GameHandler& gameHandler,
                                          InventoryScreen& inventoryScreen) {
-    if (!showInspectWindow_) return;
+    if (!showInspectWindow_) {
+        inspectWindowAutoRequestGuid_ = 0;
+        return;
+    }
 
     // Lazy-load SpellItemEnchantment.dbc for enchant name lookup
     static std::unordered_map<uint32_t, std::string> s_enchantNames;
@@ -2432,6 +2437,17 @@ void SocialPanel::renderInspectWindow(game::GameHandler& gameHandler,
     ImGui::SetNextWindowPos(ImVec2(350, 120), ImGuiCond_FirstUseEver);
 
     const game::GameHandler::InspectResult* result = gameHandler.getInspectResult();
+    const uint64_t targetGuid = gameHandler.getTargetGuid();
+    auto target = gameHandler.getTarget();
+    const bool targetIsPlayer =
+        target && target->getType() == game::ObjectType::PLAYER && targetGuid != 0;
+    if (targetIsPlayer &&
+        inspectWindowAutoRequestGuid_ != targetGuid &&
+        (!result || result->guid != targetGuid)) {
+        inspectWindowAutoRequestGuid_ = targetGuid;
+        gameHandler.inspectTarget();
+        result = gameHandler.getInspectResult();
+    }
 
     std::string title = result ? ("Inspect: " + result->playerName + "###InspectWin")
                                 : "Inspect###InspectWin";
@@ -2459,16 +2475,6 @@ void SocialPanel::renderInspectWindow(game::GameHandler& gameHandler,
             ImGui::TextColored(classColorVec4(cid), "(%s)", classNameStr(cid));
         }
     }
-    ImGui::SameLine();
-    ImGui::TextDisabled("  %u talent pts", result->totalTalents);
-    if (result->unspentTalents > 0) {
-        ImGui::SameLine();
-        ImGui::TextColored(colors::kSoftRed, "(%u unspent)", result->unspentTalents);
-    }
-    if (result->talentGroups > 1) {
-        ImGui::SameLine();
-        ImGui::TextDisabled("  Dual spec (active %u)", static_cast<unsigned>(result->activeTalentGroup) + 1);
-    }
 
     ImGui::Separator();
 
@@ -2477,8 +2483,198 @@ void SocialPanel::renderInspectWindow(game::GameHandler& gameHandler,
     for (int s = 0; s < 19; ++s) {
         if (result->itemEntries[s] != 0) { hasAnyGear = true; break; }
     }
+    const auto* visibleEquipment = game::isActiveExpansion("tbc")
+        ? gameHandler.getOtherPlayerVisibleEquipment(result->guid)
+        : nullptr;
+    bool hasVisibleEquipment = false;
+    if (visibleEquipment) {
+        for (uint32_t displayId : *visibleEquipment) {
+            if (displayId != 0) {
+                hasVisibleEquipment = true;
+                break;
+            }
+        }
+    }
 
-    if (!hasAnyGear) {
+    struct InspectGearSlot {
+        uint32_t entry = 0;
+        uint32_t displayId = 0;
+        uint16_t enchantId = 0;
+        const game::ItemQueryResponseData* info = nullptr;
+        bool loading = false;
+    };
+
+    const bool usingVisibleFallback = !hasAnyGear && hasVisibleEquipment;
+    std::array<InspectGearSlot, 19> gearSlots{};
+
+    for (int s = 0; s < 19; ++s) {
+        if (hasAnyGear) {
+            const uint32_t entry = result->itemEntries[s];
+            if (entry == 0) continue;
+            gearSlots[s].entry = entry;
+            gearSlots[s].enchantId = result->enchantIds[s];
+            gearSlots[s].info = gameHandler.getItemInfo(entry);
+            if (gearSlots[s].info) {
+                gearSlots[s].displayId = gearSlots[s].info->displayInfoId;
+            } else {
+                gearSlots[s].loading = true;
+                gameHandler.ensureItemInfo(entry);
+            }
+        } else if (usingVisibleFallback) {
+            const uint32_t entry = (*visibleEquipment)[s];
+            if (entry == 0) continue;
+            gearSlots[s].entry = entry;
+            gearSlots[s].info = gameHandler.getItemInfo(entry);
+            if (gearSlots[s].info) {
+                gearSlots[s].displayId = gearSlots[s].info->displayInfoId;
+            } else {
+                gearSlots[s].loading = true;
+                gameHandler.ensureItemInfo(entry);
+            }
+        }
+    }
+
+    auto renderInspectSlot = [&](int slotIndex, float size) {
+        const auto& slot = gearSlots[slotIndex];
+        const bool empty = slot.entry == 0 && slot.displayId == 0;
+        const char* label = kSlotNames[slotIndex];
+        ImDrawList* drawList = ImGui::GetWindowDrawList();
+        ImVec2 pos = ImGui::GetCursorScreenPos();
+
+        ImVec4 qColor = slot.info
+            ? InventoryScreen::getQualityColor(static_cast<game::ItemQuality>(slot.info->quality))
+            : ImVec4(0.45f, 0.48f, 0.56f, 1.0f);
+        ImU32 borderCol = empty
+            ? IM_COL32(70, 70, 80, 190)
+            : ImGui::ColorConvertFloat4ToU32(qColor);
+        ImU32 bgCol = empty ? IM_COL32(25, 25, 32, 190) : IM_COL32(40, 35, 30, 220);
+
+        VkDescriptorSet iconTex = (!empty && slot.displayId != 0)
+            ? inventoryScreen.getItemIcon(slot.displayId)
+            : VK_NULL_HANDLE;
+        if (iconTex) {
+            drawList->AddImage((ImTextureID)(uintptr_t)iconTex, pos,
+                               ImVec2(pos.x + size, pos.y + size));
+            drawList->AddRect(pos, ImVec2(pos.x + size, pos.y + size),
+                              borderCol, 0.0f, 0, 2.0f);
+        } else {
+            drawList->AddRectFilled(pos, ImVec2(pos.x + size, pos.y + size), bgCol);
+            drawList->AddRect(pos, ImVec2(pos.x + size, pos.y + size),
+                              borderCol, 0.0f, 0, empty ? 1.0f : 2.0f);
+
+            char abbr[4] = {};
+            if (slot.loading) {
+                abbr[0] = '.';
+                abbr[1] = '.';
+            } else if (slot.info && !slot.info->name.empty()) {
+                abbr[0] = slot.info->name[0];
+                if (slot.info->name.size() > 1) abbr[1] = slot.info->name[1];
+            } else {
+                abbr[0] = label[0];
+                if (label[1]) abbr[1] = label[1];
+            }
+            float textW = ImGui::CalcTextSize(abbr).x;
+            drawList->AddText(ImVec2(pos.x + (size - textW) * 0.5f, pos.y + size * 0.3f),
+                              empty ? IM_COL32(85, 85, 95, 180) : borderCol, abbr);
+        }
+
+        if (slot.enchantId != 0) {
+            drawList->AddText(ImVec2(pos.x + size - 10.0f, pos.y + 1.0f),
+                              IM_COL32(150, 220, 255, 240), "*");
+        }
+
+        ImGui::InvisibleButton("slot", ImVec2(size, size));
+        if (ImGui::IsItemHovered()) {
+            if (slot.info && slot.info->valid) {
+                inventoryScreen.renderItemTooltip(*slot.info);
+            } else {
+                ImGui::BeginTooltip();
+                ImGui::TextDisabled("%s", label);
+                if (slot.entry != 0) {
+                    ImGui::Text("Item #%u", static_cast<unsigned>(slot.entry));
+                    ImGui::TextDisabled("Loading item details...");
+                } else if (slot.displayId != 0) {
+                    ImGui::Text("Display ID %u", static_cast<unsigned>(slot.displayId));
+                } else {
+                    ImGui::TextDisabled("Empty");
+                }
+                ImGui::EndTooltip();
+            }
+        }
+    };
+
+    auto renderInspectPaperDoll = [&]() {
+        static constexpr int leftSlots[] = {0, 1, 2, 14, 4, 3, 18, 8};
+        static constexpr int rightSlots[] = {9, 5, 6, 7, 10, 11, 12, 13};
+        static constexpr int weaponSlots[] = {15, 16, 17};
+        constexpr float slotSize = 36.0f;
+        constexpr float previewW = 140.0f;
+
+        ImGui::TextColored(ui::colors::kWarmGold, "Equipment");
+        if (usingVisibleFallback) {
+            ImGui::SameLine();
+            ImGui::TextDisabled("(visible)");
+            if (ImGui::IsItemHovered()) {
+                ImGui::BeginTooltip();
+                ImGui::TextDisabled("Showing public visible equipment fields.");
+                ImGui::EndTooltip();
+            }
+        }
+        ImGui::Separator();
+
+        float contentStartX = ImGui::GetCursorPosX();
+        float rightColX = contentStartX + slotSize + 8.0f + previewW + 8.0f;
+        float previewStartY = ImGui::GetCursorScreenPos().y;
+
+        for (int r = 0; r < 8; ++r) {
+            ImGui::PushID(leftSlots[r]);
+            renderInspectSlot(leftSlots[r], slotSize);
+            ImGui::PopID();
+
+            ImGui::SameLine(rightColX);
+            ImGui::PushID(rightSlots[r]);
+            renderInspectSlot(rightSlots[r], slotSize);
+            ImGui::PopID();
+        }
+
+        float previewEndY = ImGui::GetCursorScreenPos().y;
+        float previewX = ImGui::GetWindowPos().x + contentStartX + slotSize + 8.0f;
+        float previewH = previewEndY - previewStartY;
+        ImVec2 pMin(previewX, previewStartY);
+        ImVec2 pMax(previewX + previewW, previewStartY + previewH);
+        ImDrawList* drawList = ImGui::GetWindowDrawList();
+        drawList->AddRectFilled(pMin, pMax, IM_COL32(13, 13, 25, 210));
+        drawList->AddRect(pMin, pMax, IM_COL32(60, 60, 80, 200));
+
+        std::string centerName = result->playerName;
+        ImVec2 nameSize = ImGui::CalcTextSize(centerName.c_str());
+        drawList->AddText(ImVec2(pMin.x + (previewW - nameSize.x) * 0.5f, pMin.y + 14.0f),
+                          IM_COL32(220, 220, 235, 230), centerName.c_str());
+        auto ent = gameHandler.getEntityManager().getEntity(result->guid);
+        uint8_t cid = entityClassId(ent.get());
+        if (cid != 0) {
+            const char* cls = classNameStr(cid);
+            ImVec2 classSize = ImGui::CalcTextSize(cls);
+            drawList->AddText(ImVec2(pMin.x + (previewW - classSize.x) * 0.5f, pMin.y + 34.0f),
+                              ImGui::ColorConvertFloat4ToU32(classColorVec4(cid)), cls);
+        }
+        const char* sourceText = usingVisibleFallback ? "Visible gear" : "Inspect gear";
+        ImVec2 srcSize = ImGui::CalcTextSize(sourceText);
+        drawList->AddText(ImVec2(pMin.x + (previewW - srcSize.x) * 0.5f, pMax.y - 24.0f),
+                          IM_COL32(150, 150, 165, 210), sourceText);
+
+        ImGui::Spacing();
+        ImGui::Separator();
+        ImGui::SetCursorPosX(contentStartX + slotSize + 8.0f);
+        for (int i = 0; i < 3; ++i) {
+            if (i > 0) ImGui::SameLine();
+            ImGui::PushID(weaponSlots[i]);
+            renderInspectSlot(weaponSlots[i], slotSize);
+            ImGui::PopID();
+        }
+    };
+
+    if (!hasAnyGear && !hasVisibleEquipment) {
         ImGui::TextDisabled("Equipment data not yet available.");
         ImGui::TextDisabled("(Gear loads after the player is inspected in-range)");
     } else {
@@ -2503,76 +2699,7 @@ void SocialPanel::renderInspectWindow(game::GameHandler& gameHandler,
             ImGui::TextDisabled("(%d/%d slots loaded)", iLevelCount,
                 [&]{ int c=0; for(int s=0;s<19;++s){if(s==3||s==18)continue;if(result->itemEntries[s])++c;} return c; }());
         }
-        if (ImGui::BeginChild("##inspect_gear", ImVec2(0, 0), false)) {
-            constexpr float kIconSz = 28.0f;
-            for (int s = 0; s < 19; ++s) {
-                uint32_t entry = result->itemEntries[s];
-                if (entry == 0) continue;
-
-                const game::ItemQueryResponseData* info = gameHandler.getItemInfo(entry);
-                if (!info) {
-                    gameHandler.ensureItemInfo(entry);
-                    ImGui::PushID(s);
-                    ImGui::TextDisabled("[%s]  (loading…)", kSlotNames[s]);
-                    ImGui::PopID();
-                    continue;
-                }
-
-                ImGui::PushID(s);
-                auto qColor = InventoryScreen::getQualityColor(
-                    static_cast<game::ItemQuality>(info->quality));
-                uint16_t enchantId = result->enchantIds[s];
-
-                // Item icon
-                VkDescriptorSet iconTex = inventoryScreen.getItemIcon(info->displayInfoId);
-                if (iconTex) {
-                    ImGui::Image((ImTextureID)(uintptr_t)iconTex, ImVec2(kIconSz, kIconSz),
-                                 ImVec2(0,0), ImVec2(1,1),
-                                 colors::kWhite, qColor);
-                } else {
-                    ImGui::GetWindowDrawList()->AddRectFilled(
-                        ImGui::GetCursorScreenPos(),
-                        ImVec2(ImGui::GetCursorScreenPos().x + kIconSz,
-                               ImGui::GetCursorScreenPos().y + kIconSz),
-                        IM_COL32(40, 40, 50, 200));
-                    ImGui::Dummy(ImVec2(kIconSz, kIconSz));
-                }
-                bool hovered = ImGui::IsItemHovered();
-
-                ImGui::SameLine();
-                ImGui::SetCursorPosY(ImGui::GetCursorPosY() + (kIconSz - ImGui::GetTextLineHeight()) * 0.5f);
-                ImGui::BeginGroup();
-                ImGui::TextDisabled("%s", kSlotNames[s]);
-                ImGui::TextColored(qColor, "%s", info->name.c_str());
-                // Enchant indicator on the same row as the name
-                if (enchantId != 0) {
-                    auto enchIt = s_enchantNames.find(enchantId);
-                    const std::string& enchName = (enchIt != s_enchantNames.end())
-                                                  ? enchIt->second : std::string{};
-                    ImGui::SameLine();
-                    if (!enchName.empty()) {
-                        ImGui::TextColored(ImVec4(0.6f, 0.85f, 1.0f, 1.0f),
-                            "\xe2\x9c\xa6 %s", enchName.c_str());  // UTF-8 ✦
-                    } else {
-                        ImGui::TextColored(ImVec4(0.6f, 0.85f, 1.0f, 1.0f), "\xe2\x9c\xa6");
-                        if (ImGui::IsItemHovered())
-                            ImGui::SetTooltip("Enchanted (ID %u)", static_cast<unsigned>(enchantId));
-                    }
-                }
-                ImGui::EndGroup();
-                hovered = hovered || ImGui::IsItemHovered();
-
-                if (hovered && info->valid) {
-                    inventoryScreen.renderItemTooltip(*info);
-                } else if (hovered) {
-                    ImGui::SetTooltip("%s", info->name.c_str());
-                }
-
-                ImGui::PopID();
-                ImGui::Spacing();
-            }
-        }
-        ImGui::EndChild();
+        renderInspectPaperDoll();
     }
 
     // Arena teams (WotLK — from MSG_INSPECT_ARENA_TEAMS)


### PR DESCRIPTION
## Summary

- Decode TBC visible item update fields as item entries and resolve them through item data for other players.
- Populate the inspect window from visible equipment data, with a paper-doll style gear layout instead of stale talent-focused output.
- Ignore local `.env` files.

## Testing

- `cmake --build /Users/joshand/code/WoWee/build --target wowee -j 2`
