### PR TITLE
fix(tbc): map server emote IDs before animations

### DIFF
--- a/include/rendering/animation/emote_registry.hpp
+++ b/include/rendering/animation/emote_registry.hpp
@@ -39,8 +39,12 @@ public:
     /// Look up an emote by chat command (e.g. "dance", "wave").
     std::optional<EmoteResult> findEmote(const std::string& command) const;
 
-    /// Get the animation ID for a DBC emote ID.
+    /// Get the animation ID for an EmotesText.dbc text-emote ID.
     uint32_t animByDbcId(uint32_t dbcId) const;
+
+    /// Get the animation ID for an Emotes.dbc emote ID, as used by SMSG_EMOTE
+    /// and UNIT_NPC_EMOTESTATE.
+    uint32_t animByEmotesId(uint32_t emoteId) const;
 
     /// Get the emote state variant (looping) for a one-shot emote animation.
     uint32_t getStateVariant(uint32_t oneShotAnimId) const;
@@ -71,6 +75,7 @@ private:
     bool loaded_ = false;
     std::unordered_map<std::string, EmoteInfo> emoteTable_;
     std::unordered_map<uint32_t, const EmoteInfo*> emoteByDbcId_;
+    std::unordered_map<uint32_t, uint32_t> animByEmotesId_;
 };
 
 } // namespace rendering

--- a/include/rendering/animation_controller.hpp
+++ b/include/rendering/animation_controller.hpp
@@ -69,6 +69,7 @@ public:
                                            const std::string& senderName,
                                            const std::string* targetName = nullptr);
     static uint32_t getEmoteAnimByDbcId(uint32_t dbcId);
+    static uint32_t getEmoteAnimByEmotesId(uint32_t emoteId);
 
     // ── Targeting / combat ─────────────────────────────────────────────────
     void setTargetPosition(const glm::vec3* pos);

--- a/src/core/entity_spawner.cpp
+++ b/src/core/entity_spawner.cpp
@@ -2273,8 +2273,11 @@ void EntitySpawner::spawnOnlineCreature(uint64_t guid, uint32_t displayId, float
                 npcEmote = std::static_pointer_cast<game::Unit>(entity)->getNpcEmoteState();
             }
         }
-        if (npcEmote != 0 && charRenderer->hasAnimation(instanceId, npcEmote)) {
-            charRenderer->playAnimation(instanceId, npcEmote, true);
+        uint32_t npcEmoteAnim = npcEmote != 0
+            ? rendering::AnimationController::getEmoteAnimByEmotesId(npcEmote)
+            : 0;
+        if (npcEmoteAnim != 0 && charRenderer->hasAnimation(instanceId, npcEmoteAnim)) {
+            charRenderer->playAnimation(instanceId, npcEmoteAnim, true);
         } else if (charRenderer->hasAnimation(instanceId, rendering::anim::BIRTH)) {
             // Play birth animation (one-shot) — will return to STAND after
             charRenderer->playAnimation(instanceId, rendering::anim::BIRTH, false);

--- a/src/game/chat_handler.cpp
+++ b/src/game/chat_handler.cpp
@@ -189,10 +189,14 @@ void ChatHandler::registerOpcodes(DispatchTable& table) {
     table[Opcode::SMSG_EMOTE] = [this](network::Packet& packet) {
         if (owner_.getState() != WorldState::IN_WORLD) return;
         if (!packet.hasRemaining(12)) return;
-        uint32_t emoteAnim  = packet.readUInt32();
+        uint32_t emoteId    = packet.readUInt32();
         uint64_t sourceGuid = packet.readUInt64();
-        if (owner_.emoteAnimCallbackRef() && sourceGuid != 0)
-            owner_.emoteAnimCallbackRef()(sourceGuid, emoteAnim);
+        uint32_t animId = rendering::AnimationController::getEmoteAnimByEmotesId(emoteId);
+        if (owner_.emoteAnimCallbackRef() && sourceGuid != 0 && animId != 0) {
+            owner_.emoteAnimCallbackRef()(sourceGuid, animId);
+        } else if (emoteId != 0 && animId == 0) {
+            LOG_DEBUG("SMSG_EMOTE emoteId=", emoteId, " had no Emotes.dbc animation mapping");
+        }
     };
     table[Opcode::SMSG_CHANNEL_NOTIFY] = [this](network::Packet& packet) {
         if (owner_.getState() == WorldState::IN_WORLD ||

--- a/src/game/entity_controller.cpp
+++ b/src/game/entity_controller.cpp
@@ -10,6 +10,7 @@
 #include "core/logger.hpp"
 #include "core/coordinates.hpp"
 #include "network/world_socket.hpp"
+#include "rendering/animation_controller.hpp"
 #include <algorithm>
 #include <cstring>
 #include <zlib.h>
@@ -915,7 +916,12 @@ EntityController::UnitFieldUpdateResult EntityController::applyUnitFieldsOnUpdat
             unit->setNpcEmoteState(val);
             // Fire emote animation callback so entity_spawner can update the NPC's idle anim
             if (val != oldEmote && owner_.emoteAnimCallbackRef()) {
-                owner_.emoteAnimCallbackRef()(block.guid, val);
+                uint32_t animId = val != 0 ? rendering::AnimationController::getEmoteAnimByEmotesId(val) : 0;
+                if (val == 0 || animId != 0) {
+                    owner_.emoteAnimCallbackRef()(block.guid, animId);
+                } else {
+                    LOG_DEBUG("UNIT_NPC_EMOTESTATE emoteId=", val, " had no Emotes.dbc animation mapping");
+                }
             }
         }
         // Power/maxpower range checks AFTER all specific fields

--- a/src/rendering/animation/emote_registry.cpp
+++ b/src/rendering/animation/emote_registry.cpp
@@ -55,6 +55,65 @@ static uint32_t getEmoteStateVariantStatic(uint32_t oneShotAnimId) {
     return it != kStateMap.end() ? it->second : 0;
 }
 
+static std::unordered_map<uint32_t, uint32_t> makeFallbackEmotesIdMap() {
+    // Emotes.dbc IDs used on classic-family MaNGOS/CMaNGOS servers.
+    return {
+        {1, anim::EMOTE_TALK},
+        {2, anim::EMOTE_BOW},
+        {3, anim::EMOTE_WAVE},
+        {4, anim::EMOTE_CHEER},
+        {5, anim::EMOTE_EXCLAMATION},
+        {6, anim::EMOTE_QUESTION},
+        {7, anim::EMOTE_EAT},
+        {10, anim::EMOTE_DANCE},
+        {11, anim::EMOTE_LAUGH},
+        {12, anim::EMOTE_SLEEP},
+        {13, anim::EMOTE_SIT_GROUND},
+        {14, anim::EMOTE_RUDE},
+        {15, anim::EMOTE_ROAR},
+        {16, anim::EMOTE_KNEEL},
+        {17, anim::EMOTE_KISS},
+        {18, anim::EMOTE_CRY},
+        {19, anim::EMOTE_CHICKEN},
+        {20, anim::EMOTE_BEG},
+        {21, anim::EMOTE_APPLAUD},
+        {22, anim::EMOTE_SHOUT},
+        {23, anim::EMOTE_FLEX},
+        {24, anim::EMOTE_SHY},
+        {25, anim::EMOTE_POINT},
+        {33, anim::COMBAT_WOUND},
+        {34, anim::COMBAT_CRITICAL},
+        {35, anim::ATTACK_UNARMED},
+        {36, anim::ATTACK_1H},
+        {37, anim::ATTACK_2H},
+        {38, anim::ATTACK_2H_LOOSE},
+        {50, anim::SPELL_PRECAST},
+        {51, anim::SPELL_CAST},
+        {53, anim::BATTLE_ROAR},
+        {60, anim::KICK},
+        {66, anim::EMOTE_SALUTE},
+        {68, anim::KNEEL_LOOP},
+        {69, anim::EMOTE_USE_STANDING},
+        {70, anim::EMOTE_WAVE},
+        {71, anim::EMOTE_CHEER},
+        {92, anim::EMOTE_EAT},
+        {94, anim::EMOTE_DANCE},
+        {113, anim::EMOTE_SALUTE},
+        {133, anim::EMOTE_USE_STANDING_NO_SHEATHE},
+        {153, anim::EMOTE_LAUGH},
+        {173, anim::EMOTE_WORK},
+        {193, anim::SPELL_PRECAST},
+        {213, anim::READY_RIFLE},
+        {214, anim::HOLD_RIFLE},
+        {233, anim::EMOTE_WORK},
+        {234, anim::EMOTE_CHOP},
+        {253, anim::EMOTE_APPLAUD},
+        {273, anim::EMOTE_TALK_EXCLAMATION},
+        {274, anim::EMOTE_TALK_QUESTION},
+        {275, anim::EMOTE_TRAIN},
+    };
+}
+
 static std::string replacePlaceholders(const std::string& text, const std::string* targetName) {
     if (text.empty()) return text;
     std::string out;
@@ -110,12 +169,17 @@ void EmoteRegistry::loadFromDbc() {
     }
 
     std::unordered_map<uint32_t, uint32_t> emoteIdToAnim;
+    animByEmotesId_.clear();
     if (auto emotesDbc = assetManager->loadDBC("Emotes.dbc"); emotesDbc && emotesDbc->isLoaded()) {
         emoteIdToAnim.reserve(emotesDbc->getRecordCount());
+        animByEmotesId_.reserve(emotesDbc->getRecordCount());
         for (uint32_t r = 0; r < emotesDbc->getRecordCount(); ++r) {
             uint32_t emoteId = emotesDbc->getUInt32(r, emL ? (*emL)["ID"] : 0);
             uint32_t animId = emotesDbc->getUInt32(r, emL ? (*emL)["AnimID"] : 2);
-            if (animId != 0) emoteIdToAnim[emoteId] = animId;
+            if (animId != 0) {
+                emoteIdToAnim[emoteId] = animId;
+                animByEmotesId_[emoteId] = animId;
+            }
         }
         LOG_DEBUG("Emotes: loaded ", emoteIdToAnim.size(), " anim mappings from Emotes.dbc");
     } else {
@@ -194,12 +258,16 @@ void EmoteRegistry::loadFromDbc() {
     } else {
         LOG_DEBUG("Emotes: loaded ", emoteTable_.size(), " commands from DBC");
     }
+    if (animByEmotesId_.empty()) {
+        animByEmotesId_ = makeFallbackEmotesIdMap();
+    }
 
     buildDbcIdIndex();
 }
 
 void EmoteRegistry::loadFallbackEmotes() {
     if (!emoteTable_.empty()) return;
+    animByEmotesId_ = makeFallbackEmotesIdMap();
     emoteTable_ = {
         {"wave",    {anim::EMOTE_WAVE,    0, false, "You wave.", "You wave at %s.", "%s waves.", "%s waves at %s.", "wave"}},
         {"bow",     {anim::EMOTE_BOW,     0, false, "You bow down graciously.", "You bow down before %s.", "%s bows down graciously.", "%s bows down before %s.", "bow"}},
@@ -253,6 +321,11 @@ uint32_t EmoteRegistry::animByDbcId(uint32_t dbcId) const {
         return it->second->animId;
     }
     return 0;
+}
+
+uint32_t EmoteRegistry::animByEmotesId(uint32_t emoteId) const {
+    auto it = animByEmotesId_.find(emoteId);
+    return it != animByEmotesId_.end() ? it->second : 0;
 }
 
 uint32_t EmoteRegistry::getStateVariant(uint32_t oneShotAnimId) const {

--- a/src/rendering/animation_controller.cpp
+++ b/src/rendering/animation_controller.cpp
@@ -128,6 +128,12 @@ uint32_t AnimationController::getEmoteAnimByDbcId(uint32_t dbcId) {
     return registry.animByDbcId(dbcId);
 }
 
+uint32_t AnimationController::getEmoteAnimByEmotesId(uint32_t emoteId) {
+    auto& registry = EmoteRegistry::instance();
+    registry.loadFromDbc();
+    return registry.animByEmotesId(emoteId);
+}
+
 // ── Spell casting ────────────────────────────────────────────────────────────
 
 void AnimationController::startSpellCast(uint32_t precastAnimId, uint32_t castAnimId, bool castLoop,


### PR DESCRIPTION
## Summary

- Resolve server emote IDs through `Emotes.dbc` before playing character animations.
- Apply the same emote-ID mapping for incoming one-shot emotes, persistent NPC emote state updates, and spawned entity emote states.
- Add a small fallback map for common CMaNGOS/classic emote IDs so TBC servers do not treat emote IDs as raw animation IDs.

This prevents newly added bots from briefly playing the death animation after `.bot add`.

## Testing

- `cmake --build /Users/joshand/code/WoWee/build --target wowee -j 2`
