### PR TITLE
fix(movement): don't strand AreaTrigger.dbc load on asset-manager timing

### DIFF
--- a/src/game/movement_handler.cpp
+++ b/src/game/movement_handler.cpp
@@ -2563,10 +2563,16 @@ void MovementHandler::activateTaxi(uint32_t destNodeId) {
 
 void MovementHandler::loadAreaTriggerDbc() {
     if (owner_.areaTriggerDbcLoadedRef()) return;
-    owner_.areaTriggerDbcLoadedRef() = true;
 
     auto* am = owner_.services().assetManager;
+    // Don't latch "loaded" until the asset manager is actually ready - the
+    // first checkAreaTriggers() tick can land well before asset manager
+    // init finishes (observed in headless mode), and latching here first
+    // would permanently strand areaTriggersRef() empty with no retry and
+    // no warning, silently disabling every area trigger for the process's
+    // lifetime.
     if (!am || !am->isInitialized()) return;
+    owner_.areaTriggerDbcLoadedRef() = true;
 
     auto dbc = am->loadDBC("AreaTrigger.dbc");
     if (!dbc || !dbc->isLoaded()) {


### PR DESCRIPTION
## Summary
- `loadAreaTriggerDbc()` set its one-shot "loaded" flag *before* confirming the asset manager was ready, instead of after. If `checkAreaTriggers()`'s first tick landed before asset manager init finished (observed reliably in headless automation, where the client can act within milliseconds of world entry), the load would silently and permanently no-op for the rest of the process's lifetime.
- Effect: every area trigger (instance portals, tavern rests, etc.) would never fire again after that point, with no warning logged anywhere.
- Fix: move the latch to after the readiness check, so it retries on later ticks instead of giving up after one bad-timing attempt.

Found and root-caused while diagnosing why the Deeprun Tram AreaTrigger (2173/2175) never fired during headless automation testing.

## Test plan
- [x] Live-validated: area triggers (Deeprun Tram entrance/exit, both directions) now fire reliably where they previously never fired at all in the affected timing window.
- [x] CI green on all platforms (Linux x86-64/arm64, macOS arm64, Windows x86-64/arm64), CodeQL, ASan/UBSan sanitizer build, Semgrep — see https://github.com/paleophyte/WoWee/pull/3