### PR TITLE
fix(movement): correctly parse packed guids in TBC movement handlers

### DIFF
--- a/src/game/movement_handler.cpp
+++ b/src/game/movement_handler.cpp
@@ -1093,9 +1093,14 @@ void MovementHandler::handleMoveSetSpeed(network::Packet& packet) {
 }
 
 void MovementHandler::handleOtherPlayerMovement(network::Packet& packet) {
-    const bool otherMoveTbc = isPreWotlk();
-    uint64_t moverGuid = otherMoveTbc
-        ? packet.readUInt64() : packet.readPackedGuid();
+    // Same packed-guid mismatch found and fixed for MSG_MOVE_TELEPORT_ACK:
+    // CMaNGOS sends a packed guid here on TBC too, not a raw UInt64. Reading
+    // it as raw corrupted moverGuid, so getEntity(moverGuid) below always
+    // missed - the entity still existed (created fine), but its position
+    // never updated from these packets. Live-observed as another player's
+    // tracked position staying frozen at wherever they were first spotted,
+    // even while they kept walking.
+    uint64_t moverGuid = packet.readPackedGuid();
     if (moverGuid == owner_.getPlayerGuid() || moverGuid == 0) {
         return;
     }
@@ -1712,19 +1717,26 @@ void MovementHandler::handleMonsterMoveTransport(network::Packet& packet) {
 // ============================================================
 
 void MovementHandler::handleTeleportAck(network::Packet& packet) {
-    const bool taTbc = isPreWotlk();
-    if (packet.getRemainingSize() < (taTbc ? 8u : 4u)) {
+    if (packet.getRemainingSize() < 1u) {
         LOG_WARNING("MSG_MOVE_TELEPORT_ACK too short");
         return;
     }
 
-    uint64_t guid = taTbc
-        ? packet.readUInt64() : packet.readPackedGuid();
+    // CMaNGOS sends a packed guid here on every expansion, including TBC -
+    // confirmed by live packet capture: reading a raw UInt64 instead
+    // misaligned every field after it, so the guid never matched the local
+    // player and the position update was silently dropped as "remote entity".
+    uint64_t guid = packet.readPackedGuid();
     if (!packet.hasRemaining(4)) return;
     uint32_t counter = packet.readUInt32();
 
     const bool taNoFlags2 = isPreWotlk();
-    const size_t minMoveSz = taNoFlags2 ? (4 + 4 + 4 * 4) : (4 + 2 + 4 + 4 * 4);
+    // Pre-WotLK sends one extra byte here that isn't part of the documented
+    // MovementInfo layout - confirmed by live capture (byte value 0x04,
+    // constant across samples) and verified against a known ground-truth
+    // teleport target (.go xyz to ironforge-city decoded to the exact
+    // expected x/y/z only once this byte was accounted for).
+    const size_t minMoveSz = taNoFlags2 ? (4 + 4 + 1 + 4 * 4) : (4 + 2 + 4 + 4 * 4);
     if (packet.getRemainingSize() < minMoveSz) {
         LOG_WARNING("MSG_MOVE_TELEPORT_ACK: not enough data for movement info");
         return;
@@ -1734,6 +1746,8 @@ void MovementHandler::handleTeleportAck(network::Packet& packet) {
     if (!taNoFlags2)
         packet.readUInt16();  // moveFlags2 (WotLK only)
     uint32_t moveTime = packet.readUInt32();
+    if (taNoFlags2)
+        packet.readUInt8();  // unknown byte, pre-WotLK only (see comment above)
     float serverX = packet.readFloat();
     float serverY = packet.readFloat();
     float serverZ = packet.readFloat();


### PR DESCRIPTION
## Summary
- `handleTeleportAck` (`MSG_MOVE_TELEPORT_ACK`) and `handleOtherPlayerMovement` both assumed CMaNGOS sends a raw `UInt64` guid on pre-WotLK and only switches to a packed guid on WotLK+. Live packet capture against a CMaNGOS TBC server shows it sends a packed guid in both cases on every expansion, TBC included.
- `handleTeleportAck` also fixes a second, separate misalignment: pre-WotLK sends one undocumented byte between `moveTime` and the position floats that wasn't being consumed (confirmed via live capture - constant byte value `0x04` - and verified against a known ground-truth teleport target).

## Impact
- Same-map GM teleports (`.appear`/`.summon`/`.go`/`.tele`) went completely unhandled on TBC before this fix - the guid never matched the local player so the position update was silently dropped as "remote entity."
- Other players' tracked positions stayed frozen at wherever they were first spotted, even while they kept moving, since `getEntity(moverGuid)` always missed on the corrupted guid.

## Test plan
- [x] Builds `wowee.exe` clean standalone from `master`.
- [x] Live-validated against a CMaNGOS TBC server: GM teleports now apply correctly, and other players' positions update continuously instead of freezing.
- [x] Verified this branch merges cleanly against current upstream `master` with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)