### PR TITLE
feat(macos): sign and notarize distribution builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,7 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [ master ]
   pull_request:
@@ -156,7 +157,8 @@ jobs:
     - name: Configure
       run: |
         BREW=$(brew --prefix)
-        export PKG_CONFIG_PATH="$BREW/lib/pkgconfig:$(brew --prefix ffmpeg)/lib/pkgconfig:$(brew --prefix openssl@3)/lib/pkgconfig:$(brew --prefix vulkan-loader)/lib/pkgconfig:$(brew --prefix shaderc)/lib/pkgconfig"
+        PKG_CONFIG_PATH="$BREW/lib/pkgconfig:$(brew --prefix ffmpeg)/lib/pkgconfig:$(brew --prefix openssl@3)/lib/pkgconfig:$(brew --prefix vulkan-loader)/lib/pkgconfig:$(brew --prefix shaderc)/lib/pkgconfig"
+        export PKG_CONFIG_PATH
         cmake -S . -B build \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
@@ -166,18 +168,18 @@ jobs:
           -DWOWEE_BUILD_TESTS=ON
 
     - name: Assert AMD FSR2 target
-      run: cmake --build build --target wowee_fsr2_amd_vk --parallel $(sysctl -n hw.logicalcpu)
+      run: cmake --build build --target wowee_fsr2_amd_vk --parallel "$(sysctl -n hw.logicalcpu)"
 
     - name: Assert AMD FSR3 framegen probe target (if present)
       run: |
         if cmake --build build --target help | grep -q 'wowee_fsr3_framegen_amd_vk_probe'; then
-          cmake --build build --target wowee_fsr3_framegen_amd_vk_probe --parallel $(sysctl -n hw.logicalcpu)
+          cmake --build build --target wowee_fsr3_framegen_amd_vk_probe --parallel "$(sysctl -n hw.logicalcpu)"
         else
           echo "FSR3 framegen probe target not generated for this SDK layout; continuing."
         fi
 
     - name: Build
-      run: cmake --build build --parallel $(sysctl -n hw.logicalcpu)
+      run: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
 
     - name: Run tests
       run: cd build && ctest --output-on-failure
@@ -190,8 +192,12 @@ jobs:
       run: |
         if [ -z "${APPLE_CERT_P12}" ] || [ -z "${APPLE_CERT_PASSWORD}" ] || \
            [ -z "${APPLE_SIGNING_IDENTITY}" ]; then
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "::error::Apple Developer ID secrets are required for trusted macOS builds."
+            exit 1
+          fi
           echo "MACOS_SIGNING_ENABLED=false" >> "${GITHUB_ENV}"
-          echo "::warning::Apple Developer ID secrets are absent; using ad-hoc signing."
+          echo "::warning::Apple secrets are unavailable to this pull request; using ad-hoc signing."
           exit 0
         fi
 
@@ -224,17 +230,17 @@ jobs:
         cp build/bin/asset_extract Wowee.app/Contents/MacOS/
 
         # Extraction scripts and GUI remain available for advanced users.
-        cp extract_assets.sh Wowee.app/Contents/MacOS/
-        cp tools/asset_pipeline_gui.py Wowee.app/Contents/MacOS/
+        cp extract_assets.sh Wowee.app/Contents/Resources/
+        cp tools/asset_pipeline_gui.py Wowee.app/Contents/Resources/
 
         # Assets (exclude proprietary music)
         rsync -a --exclude='Original Music' build/bin/assets/ \
-          Wowee.app/Contents/MacOS/assets/
+          Wowee.app/Contents/Resources/assets/
 
         # Data directory (git-tracked redistributable files only)
         git ls-files Data/ | while read -r f; do
-          mkdir -p "Wowee.app/Contents/MacOS/$(dirname "$f")"
-          cp "$f" "Wowee.app/Contents/MacOS/$f"
+          mkdir -p "Wowee.app/Contents/Resources/$(dirname "$f")"
+          cp "$f" "Wowee.app/Contents/Resources/$f"
         done
 
         # The Vulkan loader is not a graphics driver. Bundle MoltenVK and its
@@ -301,6 +307,9 @@ jobs:
         fi
         bash tools/macos/sign_app.sh Wowee.app "${IDENTITY}"
         bash tools/macos/sign_app.sh "Wowee Asset Extractor.app" "${IDENTITY}"
+        bash tools/macos/verify_signature.sh Wowee.app "${IDENTITY}"
+        bash tools/macos/verify_signature.sh \
+          "Wowee Asset Extractor.app" "${IDENTITY}"
 
     - name: Verify bundled dylibs
       run: |
@@ -342,6 +351,12 @@ jobs:
           exit 1
         fi
 
+        if [ "${MACOS_SIGNING_ENABLED}" = "true" ]; then
+          codesign --force --sign "${APPLE_SIGNING_IDENTITY}" \
+            --timestamp Wowee.dmg
+          codesign --verify --strict --verbose=2 Wowee.dmg
+        fi
+
     - name: Notarize and staple DMG
       env:
         APPLE_NOTARY_KEY: ${{ secrets.APPLE_NOTARY_KEY_P8_BASE64 }}
@@ -351,7 +366,11 @@ jobs:
         if [ "${MACOS_SIGNING_ENABLED}" != "true" ] || \
            [ -z "${APPLE_NOTARY_KEY}" ] || [ -z "${APPLE_NOTARY_KEY_ID}" ] || \
            [ -z "${APPLE_NOTARY_ISSUER_ID}" ]; then
-          echo "::warning::Notarization credentials are absent; DMG cannot be stapled."
+          if [ "${GITHUB_EVENT_NAME}" != "pull_request" ]; then
+            echo "::error::Notarization credentials are required for trusted macOS builds."
+            exit 1
+          fi
+          echo "::warning::Notarization credentials are unavailable to this pull request."
           exit 0
         fi
 
@@ -364,6 +383,8 @@ jobs:
           --wait --timeout 30m
         xcrun stapler staple Wowee.dmg
         xcrun stapler validate Wowee.dmg
+        spctl --assess --type open --context context:primary-signature \
+          --verbose=2 Wowee.dmg
 
     - name: Upload DMG
       uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,7 @@ jobs:
         cmake -LA -N build | grep -E '^CMAKE_BUILD_TYPE:STRING=Release$'
 
     - name: Build
-      run: cmake --build build --parallel $(nproc)
+      run: cmake --build build --parallel "$(nproc)"
 
     - name: Package
       run: |
@@ -122,7 +122,8 @@ jobs:
     - name: Configure
       run: |
         BREW=$(brew --prefix)
-        export PKG_CONFIG_PATH="$BREW/lib/pkgconfig:$(brew --prefix ffmpeg)/lib/pkgconfig:$(brew --prefix openssl@3)/lib/pkgconfig:$(brew --prefix vulkan-loader)/lib/pkgconfig:$(brew --prefix shaderc)/lib/pkgconfig"
+        PKG_CONFIG_PATH="$BREW/lib/pkgconfig:$(brew --prefix ffmpeg)/lib/pkgconfig:$(brew --prefix openssl@3)/lib/pkgconfig:$(brew --prefix vulkan-loader)/lib/pkgconfig:$(brew --prefix shaderc)/lib/pkgconfig"
+        export PKG_CONFIG_PATH
         cmake -S . -B build \
           -DCMAKE_BUILD_TYPE=Release \
           -DCMAKE_OSX_DEPLOYMENT_TARGET=13.0 \
@@ -134,7 +135,7 @@ jobs:
         cmake -LA -N build | grep -E '^CMAKE_BUILD_TYPE:STRING=Release$'
 
     - name: Build
-      run: cmake --build build --parallel $(sysctl -n hw.logicalcpu)
+      run: cmake --build build --parallel "$(sysctl -n hw.logicalcpu)"
 
     - name: Configure Developer ID signing
       env:
@@ -144,9 +145,8 @@ jobs:
       run: |
         if [ -z "${APPLE_CERT_P12}" ] || [ -z "${APPLE_CERT_PASSWORD}" ] || \
            [ -z "${APPLE_SIGNING_IDENTITY}" ]; then
-          echo "MACOS_SIGNING_ENABLED=false" >> "${GITHUB_ENV}"
-          echo "::warning::Apple Developer ID secrets are absent; using ad-hoc signing."
-          exit 0
+          echo "::error::Apple Developer ID secrets are required for macOS releases."
+          exit 1
         fi
 
         KEYCHAIN_PATH="${RUNNER_TEMP}/wowee-signing.keychain-db"
@@ -181,17 +181,17 @@ jobs:
         cp build/bin/asset_extract Wowee.app/Contents/MacOS/
 
         # Extraction scripts and GUI
-        cp extract_assets.sh Wowee.app/Contents/MacOS/
-        cp tools/asset_pipeline_gui.py Wowee.app/Contents/MacOS/
+        cp extract_assets.sh Wowee.app/Contents/Resources/
+        cp tools/asset_pipeline_gui.py Wowee.app/Contents/Resources/
 
         # Assets (exclude proprietary music)
         rsync -a --exclude='Original Music' build/bin/assets/ \
-          Wowee.app/Contents/MacOS/assets/
+          Wowee.app/Contents/Resources/assets/
 
         # Data directory (git-tracked files only)
         git ls-files Data/ | while read -r f; do
-          mkdir -p "Wowee.app/Contents/MacOS/$(dirname "$f")"
-          cp "$f" "Wowee.app/Contents/MacOS/$f"
+          mkdir -p "Wowee.app/Contents/Resources/$(dirname "$f")"
+          cp "$f" "Wowee.app/Contents/Resources/$f"
         done
 
         # The Vulkan loader is not a graphics driver. Bundle MoltenVK and its
@@ -261,6 +261,9 @@ jobs:
         fi
         bash tools/macos/sign_app.sh Wowee.app "${IDENTITY}"
         bash tools/macos/sign_app.sh "Wowee Asset Extractor.app" "${IDENTITY}"
+        bash tools/macos/verify_signature.sh Wowee.app "${IDENTITY}"
+        bash tools/macos/verify_signature.sh \
+          "Wowee Asset Extractor.app" "${IDENTITY}"
 
     - name: Verify bundled dylibs
       run: |
@@ -279,6 +282,10 @@ jobs:
         ln -s /Applications dmg-root/Applications
         hdiutil create -volname Wowee -srcfolder dmg-root -ov -format UDZO \
           "wowee-${TAG}-macos-arm64.dmg"
+        codesign --force --sign "${APPLE_SIGNING_IDENTITY}" \
+          --timestamp "wowee-${TAG}-macos-arm64.dmg"
+        codesign --verify --strict --verbose=2 \
+          "wowee-${TAG}-macos-arm64.dmg"
 
     - name: Notarize and staple DMG
       env:
@@ -289,8 +296,8 @@ jobs:
         if [ "${MACOS_SIGNING_ENABLED}" != "true" ] || \
            [ -z "${APPLE_NOTARY_KEY}" ] || [ -z "${APPLE_NOTARY_KEY_ID}" ] || \
            [ -z "${APPLE_NOTARY_ISSUER_ID}" ]; then
-          echo "::warning::Notarization credentials are absent; DMG cannot be stapled."
-          exit 0
+          echo "::error::Notarization credentials are required for macOS releases."
+          exit 1
         fi
 
         DMG="wowee-${GITHUB_REF_NAME}-macos-arm64.dmg"
@@ -303,6 +310,8 @@ jobs:
           --wait --timeout 30m
         xcrun stapler staple "${DMG}"
         xcrun stapler validate "${DMG}"
+        spctl --assess --type open --context context:primary-signature \
+          --verbose=2 "${DMG}"
 
     - name: Upload artifact
       uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,9 @@ config.ini
 config.json
 .env
 
+# Local signing and notarization handoff material
+.secrets/
+
 # Runtime cache (floor heights, etc.)
 cache/
 

--- a/BUILD_INSTRUCTIONS.md
+++ b/BUILD_INSTRUCTIONS.md
@@ -136,14 +136,12 @@ Supports `classic`, `turtle`, `tbc`, `wotlk` targets (auto-detected if omitted).
 
 ### Running a downloaded macOS release
 
-Current GitHub releases are ad-hoc signed, not Apple Developer ID signed or
-notarized. After trying to open `Wowee.app` once and dismissing the warning, go
-to **Apple menu → System Settings → Privacy & Security**, scroll to
-**Security**, click **Open Anyway**, authenticate, and confirm **Open**. The
-button is normally available for about an hour after the failed launch.
+GitHub release DMGs are Developer ID signed, notarized by Apple, and stapled.
+Gatekeeper should accept a release downloaded from the official WoWee GitHub
+repository without an **Open Anyway** exception.
 
-This creates an exception for WoWee without disabling Gatekeeper globally. Only
-use it for a release downloaded from the official WoWee GitHub repository.
+Maintainers can find the CI credential contract and verification commands in
+[`docs/macos-distribution.md`](docs/macos-distribution.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,23 +21,10 @@ AzerothCore/ChromieCraft, TrinityCore, MaNGOS, and Turtle WoW 1.18.
 [Download the latest release](https://github.com/Kelsidavis/WoWee/releases/latest) ·
 [Read the project status](docs/status.md)
 
-> [!WARNING]
-> **macOS releases are not currently signed with an Apple Developer ID or
-> notarized.** CI applies only an ad-hoc signature, so Gatekeeper may block the
-> app. Developer ID signing and notarization require a paid Apple Developer
-> Program membership (currently US$99 per year). If you want to help fund it,
-> use the [GitHub Sponsors page](https://github.com/sponsors/Kelsidavis).
->
-> To open a release downloaded from the official WoWee GitHub page:
->
-> 1. Try to open **Wowee.app** once, then dismiss the macOS warning.
-> 2. Open **Apple menu → System Settings → Privacy & Security**.
-> 3. Scroll to **Security** and click **Open Anyway** beside the WoWee message.
->    The button is normally available for about an hour after the failed launch.
-> 4. Authenticate, confirm **Open**, and launch WoWee again.
->
-> This creates an exception for WoWee without globally disabling Gatekeeper.
-> Only override the warning for a release you obtained from this repository.
+> [!NOTE]
+> macOS release DMGs are Developer ID signed, notarized by Apple, and stapled
+> before publication. Gatekeeper should identify them as notarized Developer ID
+> software without requiring an **Open Anyway** exception.
 
 > [!IMPORTANT]
 > WoWee is an educational and research project. It contains no Blizzard

--- a/docs/macos-distribution.md
+++ b/docs/macos-distribution.md
@@ -1,0 +1,46 @@
+# macOS signing and notarization
+
+WoWee distributes two macOS apps in one DMG: `Wowee.app` and the independent
+`Wowee Asset Extractor.app` launcher. The main app also contains the
+`asset_extract` executable. Every Mach-O component is signed inside-out with a
+Developer ID Application identity and the hardened runtime before the DMG is
+signed, submitted to Apple's notary service, and stapled.
+
+The bundle keeps executables and dylibs in `Contents/MacOS` and
+`Contents/Frameworks`. Assets, expansion data, and helper scripts belong in
+`Contents/Resources`; placing unsigned data under `Contents/MacOS` prevents
+Apple from sealing the bundle correctly.
+
+## GitHub Actions secrets
+
+Configure these repository secrets before running a trusted build or creating
+a `v*` release tag:
+
+- `APPLE_DEVELOPER_ID_CERT_P12_BASE64`: base64-encoded Developer ID identity
+  and private key in PKCS#12 format
+- `APPLE_DEVELOPER_ID_CERT_PASSWORD`: PKCS#12 export password
+- `APPLE_DEVELOPER_ID_IDENTITY`: full `Developer ID Application: ...` identity
+- `APPLE_NOTARY_KEY_P8_BASE64`: base64-encoded App Store Connect API private key
+- `APPLE_NOTARY_KEY_ID`: App Store Connect API key ID
+- `APPLE_NOTARY_ISSUER_ID`: App Store Connect issuer ID
+
+The API key needs only the App Store Connect `Developer` role for notarization.
+The private `.p8` key is downloadable once, so retain an encrypted backup.
+
+Pull requests without secrets still receive an ad-hoc bundle build for compile
+and packaging coverage. Manual trusted builds and tagged release builds fail
+closed if signing or notarization credentials are absent.
+
+## Verification
+
+The workflows verify every bundled Mach-O component and run the following trust
+checks after notarization:
+
+```bash
+codesign --verify --deep --strict --verbose=2 Wowee.app
+xcrun stapler validate Wowee.dmg
+spctl --assess --type open --context context:primary-signature \
+  --verbose=2 Wowee.dmg
+```
+
+A successful DMG assessment reports `source=Notarized Developer ID`.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -133,15 +133,24 @@ int main([[maybe_unused]] int argc, [[maybe_unused]] char* argv[]) {
     std::signal(SIGTERM, crashHandler);
     std::signal(SIGINT,  crashHandler);
 #endif
-    // Change working directory to the executable's directory so relative asset
-    // paths (assets/shaders/, Data/, etc.) resolve correctly from any launch location.
+    // Change working directory so relative asset paths resolve from any launch
+    // location. A signed macOS bundle keeps data in Contents/Resources because
+    // Contents/MacOS may contain code only.
 #ifdef __APPLE__
     {
         uint32_t bufSize = 0;
         _NSGetExecutablePath(nullptr, &bufSize);
         std::string exePath(bufSize, '\0');
         _NSGetExecutablePath(exePath.data(), &bufSize);
-        if (chdir(dirname(exePath.data())) != 0) {}
+        const std::filesystem::path executableDir =
+            std::filesystem::path(exePath.c_str()).parent_path();
+        const std::filesystem::path resourceDir =
+            executableDir.parent_path() / "Resources";
+        const std::filesystem::path runtimeDir =
+            std::filesystem::is_directory(resourceDir / "assets")
+                ? resourceDir
+                : executableDir;
+        if (chdir(runtimeDir.c_str()) != 0) {}
     }
     selectMacUserDataPath();
 #elif defined(__linux__)

--- a/tools/macos/asset_extractor_launcher.sh
+++ b/tools/macos/asset_extractor_launcher.sh
@@ -23,7 +23,7 @@ if [ ! -d "${APP_PATH}" ] && [ -d "/Applications/Wowee.app" ]; then
 fi
 
 EXTRACTOR="${APP_PATH}/Contents/MacOS/asset_extract"
-BUNDLED_DATA="${APP_PATH}/Contents/MacOS/Data"
+BUNDLED_DATA="${APP_PATH}/Contents/Resources/Data"
 OUTPUT_ROOT="${HOME}/Library/Application Support/Wowee/Data"
 
 if [ ! -x "${EXTRACTOR}" ]; then

--- a/tools/macos/bundle_dependencies.py
+++ b/tools/macos/bundle_dependencies.py
@@ -7,6 +7,7 @@ import argparse
 import collections
 import pathlib
 import shutil
+import stat
 import subprocess
 import sys
 
@@ -125,6 +126,7 @@ class Bundler:
         if not destination.exists():
             shutil.copy2(canonical_source, destination)
             print(f"Bundled {canonical_source} -> {destination.name}")
+        destination.chmod(destination.stat().st_mode | stat.S_IWUSR)
         return destination
 
     def bundle(self, roots: list[pathlib.Path]) -> None:

--- a/tools/macos/sign_app.sh
+++ b/tools/macos/sign_app.sh
@@ -4,15 +4,29 @@ set -euo pipefail
 APP_PATH="${1:?usage: sign_app.sh <app> [identity]}"
 IDENTITY="${2:--}"
 
+# Homebrew bottles and downloaded resources can carry read-only modes or
+# provenance/quarantine attributes. Both interfere with deterministic bundle
+# sealing, so normalize the staged copy before applying any signature.
+chmod -R u+w "${APP_PATH}"
+xattr -cr "${APP_PATH}"
+
 if [ "${IDENTITY}" = "-" ]; then
     codesign --force --deep --sign - "${APP_PATH}"
     exit 0
 fi
 
+MAIN_EXECUTABLE="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' \
+    "${APP_PATH}/Contents/Info.plist")"
+MAIN_EXECUTABLE_PATH="${APP_PATH}/Contents/MacOS/${MAIN_EXECUTABLE}"
+
 # Sign every Mach-O component before the containing app bundle. Hardened
-# runtime and a trusted timestamp are required for Apple notarization.
+# runtime and a trusted timestamp are required for Apple notarization. Skip
+# CFBundleExecutable here because codesign resolves that path to the containing
+# bundle; signing the outer app below signs the main executable after all nested
+# code is ready.
 while IFS= read -r -d '' component; do
-    if file -b "${component}" | grep -q 'Mach-O'; then
+    if [ "${component}" != "${MAIN_EXECUTABLE_PATH}" ] && \
+       file -b "${component}" | grep -q 'Mach-O'; then
         codesign --force --sign "${IDENTITY}" \
             --options runtime --timestamp "${component}"
     fi

--- a/tools/macos/verify_bundle.sh
+++ b/tools/macos/verify_bundle.sh
@@ -8,6 +8,8 @@ CONTENTS="${APP_PATH}/Contents"
 MACOS_DIR="${CONTENTS}/MacOS"
 FRAMEWORKS_DIR="${CONTENTS}/Frameworks"
 ICD_MANIFEST="${CONTENTS}/Resources/vulkan/icd.d/MoltenVK_icd.json"
+ASSETS_DIR="${CONTENTS}/Resources/assets"
+DATA_DIR="${CONTENTS}/Resources/Data"
 
 for tool in file lipo otool codesign python3; do
     if ! command -v "${tool}" >/dev/null 2>&1; then
@@ -30,6 +32,14 @@ if [ ! -f "${FRAMEWORKS_DIR}/libMoltenVK.dylib" ]; then
 fi
 if [ ! -f "${ICD_MANIFEST}" ]; then
     echo "ERROR: app bundle is missing the MoltenVK ICD manifest" >&2
+    exit 1
+fi
+if [ ! -d "${ASSETS_DIR}" ]; then
+    echo "ERROR: app bundle is missing Contents/Resources/assets" >&2
+    exit 1
+fi
+if [ ! -d "${DATA_DIR}" ]; then
+    echo "ERROR: app bundle is missing Contents/Resources/Data" >&2
     exit 1
 fi
 

--- a/tools/macos/verify_signature.sh
+++ b/tools/macos/verify_signature.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+set -euo pipefail
+
+APP_PATH="${1:?usage: verify_signature.sh <app> [identity]}"
+IDENTITY="${2:--}"
+
+codesign --verify --deep --strict --verbose=2 "${APP_PATH}"
+
+checked=0
+while IFS= read -r -d '' component; do
+    if ! file -b "${component}" | grep -q 'Mach-O'; then
+        continue
+    fi
+
+    checked=$((checked + 1))
+    codesign --verify --strict --verbose=2 "${component}"
+
+    if [ "${IDENTITY}" != "-" ]; then
+        details="$(codesign --display --verbose=4 "${component}" 2>&1)"
+        if ! grep -Fq "Authority=${IDENTITY}" <<<"${details}"; then
+            echo "ERROR: ${component} is not signed by ${IDENTITY}" >&2
+            exit 1
+        fi
+        if ! grep -Eq '^CodeDirectory .* flags=.*\(runtime\)' <<<"${details}"; then
+            echo "ERROR: ${component} is missing the hardened runtime flag" >&2
+            exit 1
+        fi
+    fi
+done < <(find "${APP_PATH}/Contents" -type f -print0)
+
+if [ "${checked}" -eq 0 ]; then
+    echo "ERROR: no signed Mach-O components found in ${APP_PATH}" >&2
+    exit 1
+fi
+
+echo "Verified ${checked} signed Mach-O component(s) in ${APP_PATH}."


### PR DESCRIPTION
## Summary

- add Developer ID signing with hardened runtime for every bundled Mach-O component
- sign both `Wowee.app` and the standalone `Wowee Asset Extractor.app`, including the embedded `asset_extract` binary
- notarize, staple, and Gatekeeper-check macOS DMGs in trusted builds and tagged releases
- move runtime data into `Contents/Resources` and update the app to locate those resources correctly
- add strict bundle/signature verification scripts and document the required repository secrets

## Why

The previous macOS artifacts were packaged without a complete Developer ID signing and notarization path. That left the main app, asset extractor, nested dylibs, and DMG without a fail-closed release trust chain for distribution outside the Mac App Store.

## Validation

- full Linux, Windows, and macOS build matrix passed on the fork
- macOS CI built, signed, notarized, stapled, and uploaded the DMG successfully
- downloaded the CI artifact and verified the stapled ticket with `xcrun stapler validate`
- Gatekeeper accepted the CI-produced DMG, `Wowee.app`, and `Wowee Asset Extractor.app` as `Notarized Developer ID`
- verified all 22 Mach-O components in the main app and the standalone extractor executable against the expected Developer ID authority and hardened runtime
- local notarization submission was accepted by Apple and independently passed the same Gatekeeper checks

CI: https://github.com/jamesbrink/WoWee/actions/runs/29625894991

## Repository configuration

Trusted builds require the six Apple signing/notarization secrets documented in `docs/macos-distribution.md`. Release and manually dispatched trusted builds fail closed when these credentials are unavailable.
