### PR TITLE
fix: keep respawned game objects visible after leaving and returning

### DIFF
--- a/include/rendering/m2_renderer.hpp
+++ b/include/rendering/m2_renderer.hpp
@@ -250,6 +250,18 @@ struct M2Instance {
     float portalSpinAngle = 0.0f;  // Accumulated spin angle for portal rotation
     const M2ModelGPU* cachedModel = nullptr;  // Avoid per-frame hash lookups
 
+    // Result of the most recent GPU cull dispatch that actually covered this
+    // instance, matched back by instance ID (never by array index — see
+    // cullSubmittedIds_).  Defaults to visible so an instance created after the
+    // in-flight dispatch draws immediately instead of waiting ~2 frames for its
+    // first cull result.
+    uint8_t lastCullVisible = 1;
+    // Consecutive frames this instance has been culled (capped at 3), used for
+    // the HiZ `previouslyVisible` hysteresis.  Defaults to 2 ("not recently
+    // visible") so a freshly spawned instance skips the HiZ test rather than
+    // being judged against depth data that never contained it.
+    uint8_t hizPrevCulledFrames = 2;
+
     void recomputeCachedCullFactors();
 
     // Frame-skip optimization (update distant animations less frequently)
@@ -587,11 +599,19 @@ private:
     // as the depth buffer the HiZ pyramid was built from.
     glm::mat4 prevVP_{1.0f};
 
-    // Per-instance visibility from the previous frame.  Used to set the
-    // `previouslyVisible` flag (bit 3) on each CullInstance so the shader
-    // skips the HiZ test for objects that weren't rendered last frame
-    // (their depth data is unreliable).
-    std::vector<uint8_t> prevFrameVisible_;
+    // Instance IDs, in dispatch order, for the cull results a frame slot holds.
+    //
+    // The visibility SSBO is read back one full slot cycle after it is written:
+    // dispatchCullCompute() records a dispatch into this frame's command buffer,
+    // and render() reads the mapped output of the dispatch recorded on the SAME
+    // slot ~2 frames earlier.  Array indices are not stable across that gap —
+    // createInstance() appends and removeInstance() swap-removes, so slot i can
+    // easily describe a different object by the time it is read.  Recording the
+    // IDs lets render() match each result back to the instance it was computed
+    // for.  cullSubmittedIds_ is the dispatch just recorded (results not ready);
+    // cullReadableIds_ is the previous one, matching the mapped data now.
+    std::vector<uint32_t> cullSubmittedIds_[2];
+    std::vector<uint32_t> cullReadableIds_[2];
 
     // Dynamic ribbon vertex buffer (CPU-written triangle strip)
     static constexpr size_t MAX_RIBBON_VERTS = 2048;  // 9 floats each

--- a/src/rendering/m2_renderer_instance.cpp
+++ b/src/rendering/m2_renderer_instance.cpp
@@ -383,6 +383,8 @@ void M2Renderer::clear() {
     spatialGrid.clear();
     instanceIndexById.clear();
     instanceDedupMap_.clear();
+    for (auto& ids : cullSubmittedIds_) ids.clear();
+    for (auto& ids : cullReadableIds_) ids.clear();
     smokeParticles.clear();
     smokeInstanceIndices_.clear();
     portalInstanceIndices_.clear();
@@ -413,6 +415,8 @@ void M2Renderer::clearInstances() {
     spatialGrid.clear();
     instanceIndexById.clear();
     instanceDedupMap_.clear();
+    for (auto& ids : cullSubmittedIds_) ids.clear();
+    for (auto& ids : cullReadableIds_) ids.clear();
     smokeInstanceIndices_.clear();
     portalInstanceIndices_.clear();
     animatedInstanceIndices_.clear();

--- a/src/rendering/m2_renderer_render.cpp
+++ b/src/rendering/m2_renderer_render.cpp
@@ -710,6 +710,19 @@ void M2Renderer::dispatchCullCompute(VkCommandBuffer cmd, uint32_t frameIndex, c
         prevVP_ = vp;
     }
 
+    // Rotate this slot's ID log: the dispatch recorded below replaces the one
+    // whose results render() is about to consume, so the IDs it was built from
+    // become the readable set.  Done before the upload loop overwrites them, and
+    // after the early-out above, so "readable" always describes the last dispatch
+    // actually recorded on this slot.
+    if (frameIndex < 2) {
+        cullReadableIds_[frameIndex].swap(cullSubmittedIds_[frameIndex]);
+        cullSubmittedIds_[frameIndex].clear();
+        cullSubmittedIds_[frameIndex].reserve(numInstances);
+        for (uint32_t i = 0; i < numInstances; i++)
+            cullSubmittedIds_[frameIndex].push_back(instances[i].id);
+    }
+
     // --- Upload per-instance cull data (SSBO, binding 1) ---
     // The per-instance radius math used to be recomputed here every frame; it's
     // now precomputed once by recomputeCachedCullFactors() since it depends only
@@ -734,7 +747,9 @@ void M2Renderer::dispatchCullCompute(VkCommandBuffer cmd, uint32_t frameIndex, c
             // that were NOT rendered last frame (no reliable depth data).
             // Hysteresis: treat as "previously visible" unless culled for
             // 2+ consecutive frames, preventing single-frame false-cull flicker.
-            if (i < prevFrameVisible_.size() && prevFrameVisible_[i] < 2)
+            // The counter lives on the instance, so streaming churn can never
+            // pair it with a different object's history.
+            if (inst.hizPrevCulledFrames < 2)
                 flags |= 8u;
 
             input[i].sphere = glm::vec4(inst.cachedCullCenter, inst.cachedPaddedRadius);
@@ -823,27 +838,51 @@ void M2Renderer::render(VkCommandBuffer cmd, VkDescriptorSet perFrameSet, const 
     const uint32_t* visibility = static_cast<const uint32_t*>(cullOutputMapped_[frameIndex]);
     const bool gpuCullAvailable = (cullPipeline_ != VK_NULL_HANDLE && visibility != nullptr);
 
-    // Snapshot the GPU visibility results into prevFrameVisible_ so the NEXT
-    // frame's compute dispatch can set the per-instance `previouslyVisible`
-    // flag (bit 3).  We use a hysteresis counter instead of a binary flag to
-    // prevent a 1-frame-on / 1-frame-off oscillation: an object must be HiZ-
-    // culled for 2 consecutive frames before we stop considering it
-    // "previously visible".  This eliminates doodad flicker near characters
-    // caused by stale depth data from character movement.
+    // Scatter the GPU visibility results back onto the instances they were
+    // computed for.  The results belong to the dispatch recorded on this slot
+    // ~2 frames ago, so they are keyed by that dispatch's instance IDs, never by
+    // the current array index: createInstance() appends and removeInstance()
+    // swap-removes, so a respawned game object lands at the volatile tail of the
+    // array and would otherwise inherit the verdict of whatever transient object
+    // (spell visual, streamed doodad, creature) held that index two frames back
+    // — leaving it culled for as long as the churn continued.
+    //
+    // Instances with no entry in the readable set were created after that
+    // dispatch and keep their defaults: visible, and exempt from the HiZ test.
+    //
+    // hizPrevCulledFrames is a hysteresis counter rather than a binary flag: an
+    // object must be culled for 2 consecutive frames before it stops counting as
+    // "previously visible", which prevents the 1-frame-on / 1-frame-off
+    // oscillation that showed up as doodad flicker near moving characters.
     if (gpuCullAvailable) {
-        prevFrameVisible_.resize(numInstances, 0);
-        for (uint32_t i = 0; i < numInstances; ++i) {
-            if (visibility[i]) {
-                // Visible this frame — reset cull counter.
-                prevFrameVisible_[i] = 0;
+        const auto& ids = cullReadableIds_[frameIndex < 2 ? frameIndex : 0];
+        for (size_t k = 0; k < ids.size(); ++k) {
+            // Fast path: with no churn since that dispatch the ordering still
+            // matches, so skip the hash lookup.
+            M2Instance* inst = nullptr;
+            if (k < instances.size() && instances[k].id == ids[k]) {
+                inst = &instances[k];
             } else {
-                // Culled this frame — increment counter (cap at 3 to avoid overflow).
-                prevFrameVisible_[i] = std::min<uint8_t>(prevFrameVisible_[i] + 1, 3);
+                auto idxIt = instanceIndexById.find(ids[k]);
+                if (idxIt == instanceIndexById.end() || idxIt->second >= instances.size())
+                    continue;  // instance was removed since the dispatch
+                inst = &instances[idxIt->second];
+            }
+            if (visibility[k]) {
+                inst->lastCullVisible = 1;
+                inst->hizPrevCulledFrames = 0;
+            } else {
+                inst->lastCullVisible = 0;
+                inst->hizPrevCulledFrames =
+                    std::min<uint8_t>(inst->hizPrevCulledFrames + 1, 3);
             }
         }
     } else {
-        // No GPU cull data — conservatively mark all as visible (counter = 0).
-        prevFrameVisible_.assign(static_cast<size_t>(instances.size()), 0);
+        // No GPU cull data — conservatively treat everything as visible.
+        for (auto& inst : instances) {
+            inst.lastCullVisible = 1;
+            inst.hizPrevCulledFrames = 0;
+        }
     }
 
     // If GPU culling was not dispatched, fallback: compute distances on CPU
@@ -912,7 +951,10 @@ void M2Renderer::render(VkCommandBuffer cmd, VkDescriptorSet perFrameSet, const 
                 distSq = glm::dot(toCam, toCam);
                 effectiveMaxDistSq = maxRenderDistanceSq * instance.cachedEffectiveMaxDistSqFactor;
             } else if (gpuCullAvailable && i < numInstances) {
-                if (!visibility[i]) continue;
+                // Per-instance verdict scattered above — indexing visibility[]
+                // directly here would read the slot of whichever instance held
+                // this array position when the dispatch was recorded.
+                if (!instance.lastCullVisible) continue;
                 glm::vec3 toCam = instance.position - camPos;
                 distSq = glm::dot(toCam, toCam);
                 effectiveMaxDistSq = maxRenderDistanceSq * instance.cachedEffectiveMaxDistSqFactor;


### PR DESCRIPTION
## Symptom

A mailbox is visible on first approach, but after walking ~200 yards away (past the server's visibility range) and coming back, it never reappears — permanently invisible for the rest of the session, even standing right next to it.

## Cause

M2 GPU cull results are read back one frame-slot cycle after they are written. `Renderer::render` calls `dispatchCullCompute` (`src/rendering/renderer.cpp:946`), which records a compute dispatch into the current frame's command buffer; `M2Renderer::render` then reads `cullOutputMapped_[frameIndex]`, which holds the output of the dispatch recorded on that **same slot ~2 frames earlier**.

Those results were keyed by **array index**, and indices are not stable across that gap — `createInstance` appends, `removeInstance` swap-removes the tail into the hole. A game object that despawns (server out-of-range) and respawns gets a fresh instance appended at the **end** of the array: exactly the region that churns every frame as spell visuals, creatures and streamed doodads come and go. So `visibility[i]` for the mailbox was the verdict computed for whatever transient object held that slot two frames back. While the churn continues it can stay gated off indefinitely, even though the instance exists, the model is loaded, and it is in frustum and in range.

The first spawn works because that instance sits at a low, stable index.

## Fix

Match cull results to instances by **instance ID** instead of array index:

- `dispatchCullCompute` records the IDs it submitted per frame slot. `cullSubmittedIds_` is the dispatch just recorded (results not ready); `cullReadableIds_` is the previous one, matching the mapped data being read now. They rotate on each recorded dispatch, so "readable" always describes the last dispatch actually recorded on that slot.
- `render` scatters each verdict onto `M2Instance::lastCullVisible`, with a no-churn fast path (`instances[k].id == ids[k]`) that skips the hash lookup in the common case.
- Instances created after the in-flight dispatch have no entry in the readable set and keep their defaults — visible, and exempt from the HiZ test — so a respawn draws immediately instead of waiting ~2 frames for its first verdict.
- The HiZ `previouslyVisible` hysteresis counter moved from the index-keyed `prevFrameVisible_` vector onto `M2Instance::hizPrevCulledFrames`, for the same aliasing reason.

## Testing

- Full Release build, clean (the one `m2_renderer_render.cpp` warning is pre-existing `-Wunused-parameter` at line 1820).
- `ctest`: 45/45 passing.
- Not verified in-game — the change is on the render path and needs a visual repro (walk away from a mailbox past server visibility range, return, confirm it draws).

## Follow-up, not fixed here

`M2Renderer::createInstance` dedups by model+rounded position and returns an **existing** instance ID to the second caller, so a terrain tile and a server game object can end up sharing one instance. Either owner's removal then destroys it out from under the other — `EntitySpawner::gameObjectInstances_` would keep a dead ID and `spawnOnlineGameObject`'s "already have an instance" branch would `setInstanceTransform` into the void. It needs a coincidence to within 0.1 units to trigger, so it is unlikely to be this bug, but it is the same symptom class and worth a liveness check on that branch.