### PR TITLE
fix: keep game objects visible after leaving and returning to an area

### DIFF
--- a/include/rendering/m2_renderer.hpp
+++ b/include/rendering/m2_renderer.hpp
@@ -250,6 +250,23 @@ struct M2Instance {
     float portalSpinAngle = 0.0f;  // Accumulated spin angle for portal rotation
     const M2ModelGPU* cachedModel = nullptr;  // Avoid per-frame hash lookups
 
+    // Result of the most recent GPU cull dispatch that actually covered this
+    // instance, matched back by instance ID (never by array index — see
+    // cullSubmittedIds_).  Defaults to visible so an instance created after the
+    // in-flight dispatch draws immediately instead of waiting ~2 frames for its
+    // first cull result.
+    uint8_t lastCullVisible = 1;
+    // Consecutive frames this instance has been culled (capped at 3), used for
+    // the HiZ `previouslyVisible` hysteresis.  Defaults to 2 ("not recently
+    // visible") so a freshly spawned instance skips the HiZ test rather than
+    // being judged against depth data that never contained it.
+    uint8_t hizPrevCulledFrames = 2;
+    // Server game object (mailbox, chest, node, door): exempt from the adaptive
+    // ambient-doodad distance, which collapses to ~200 units in a city and hid
+    // interactable objects long before the server stopped sending them.
+    // Set by the spawner; see M2_GAME_OBJECT_MIN_RENDER_DISTANCE.
+    bool isGameObject = false;
+
     void recomputeCachedCullFactors();
 
     // Frame-skip optimization (update distant animations less frequently)
@@ -401,8 +418,18 @@ public:
     /// used for cursor picking and selection circles. Returns false for an
     /// unknown instance or a degenerate (zero-radius) model.
     bool getInstanceBounds(uint32_t instanceId, glm::vec3& outCenter, float& outRadius) const;
+    /// True while the instance is still live in the renderer. Owners that cache
+    /// instance IDs (game objects, transports) use this to notice an instance
+    /// that was dropped underneath them — e.g. by a renderer-wide clear — and
+    /// respawn it instead of silently addressing a dead handle forever.
+    bool hasInstance(uint32_t instanceId) const {
+        return instanceIndexById.find(instanceId) != instanceIndexById.end();
+    }
     void removeInstance(uint32_t instanceId);
     void removeInstances(const std::vector<uint32_t>& instanceIds);
+    /// Mark an instance as a server game object so the adaptive doodad render
+    /// distance can't cull it while the server still considers it visible.
+    void setInstanceIsGameObject(uint32_t instanceId, bool isGameObject);
     void setSkipCollision(uint32_t instanceId, bool skip);
     void setSkipWallCollision(uint32_t instanceId, bool skip);
     void clear();
@@ -410,6 +437,12 @@ public:
      *  editor's rebuild loop where the same model is re-instanced repeatedly. */
     void clearInstances();
     void cleanupUnusedModels();
+    /// Keep a model resident even while it has no instances. Game object models
+    /// are a small, bounded set (one per display ID actually encountered) that
+    /// goes instance-free every time the player leaves an area and comes back —
+    /// exactly the reap/reload churn seen in the field. Pinning them keeps that
+    /// cycle out of the picture entirely; ambient doodads still get reaped.
+    void setModelPinned(uint32_t modelId, bool pinned);
     /** Return and clear the model IDs evicted by cleanupUnusedModels() since the
      *  last call. Lets callers that track uploaded models drop stale entries. */
     std::vector<uint32_t> drainReapedModelIds();
@@ -587,11 +620,19 @@ private:
     // as the depth buffer the HiZ pyramid was built from.
     glm::mat4 prevVP_{1.0f};
 
-    // Per-instance visibility from the previous frame.  Used to set the
-    // `previouslyVisible` flag (bit 3) on each CullInstance so the shader
-    // skips the HiZ test for objects that weren't rendered last frame
-    // (their depth data is unreliable).
-    std::vector<uint8_t> prevFrameVisible_;
+    // Instance IDs, in dispatch order, for the cull results a frame slot holds.
+    //
+    // The visibility SSBO is read back one full slot cycle after it is written:
+    // dispatchCullCompute() records a dispatch into this frame's command buffer,
+    // and render() reads the mapped output of the dispatch recorded on the SAME
+    // slot ~2 frames earlier.  Array indices are not stable across that gap —
+    // createInstance() appends and removeInstance() swap-removes, so slot i can
+    // easily describe a different object by the time it is read.  Recording the
+    // IDs lets render() match each result back to the instance it was computed
+    // for.  cullSubmittedIds_ is the dispatch just recorded (results not ready);
+    // cullReadableIds_ is the previous one, matching the mapped data now.
+    std::vector<uint32_t> cullSubmittedIds_[2];
+    std::vector<uint32_t> cullReadableIds_[2];
 
     // Dynamic ribbon vertex buffer (CPU-written triangle strip)
     static constexpr size_t MAX_RIBBON_VERTS = 2048;  // 9 floats each
@@ -616,6 +657,7 @@ private:
     // Grace period for model cleanup: track when a model first became instanceless.
     // Models are only evicted after 60 seconds with no instances.
     std::unordered_map<uint32_t, std::chrono::steady_clock::time_point> modelUnusedSince_;
+    std::unordered_set<uint32_t> pinnedModelIds_;
     // Model IDs evicted by cleanupUnusedModels() since the last drain. Owners that
     // cache "already uploaded" model IDs (e.g. TerrainManager) reconcile against
     // this so a reaped model is re-loaded instead of skipped as a stale hit.

--- a/include/rendering/render_constants.hpp
+++ b/include/rendering/render_constants.hpp
@@ -33,6 +33,17 @@ constexpr float M2_CULL_RADIUS_SCALE_DIVISOR = 12.0f;
 constexpr float M2_PADDED_RADIUS_SCALE       = 1.5f;
 constexpr float M2_PADDED_RADIUS_MIN_MARGIN  = 3.0f;
 
+// Distance floor for server game objects (mailboxes, chests, nodes, doors).
+// The adaptive doodad distance collapses to its densest-scene value in any
+// populated area — a city holds ~100k M2 instances, so ambient doodads are cut
+// at 300 * viewDistanceScale, i.e. 200 world units at a mid view-distance
+// setting. Applying that to game objects hides objects the player interacts
+// with. The server only sends a game object when it is inside its own
+// visibility radius, so anything we have been told about is worth drawing:
+// this floor sits comfortably beyond any server visibility setting, leaving
+// frustum and occlusion culling to do the real work.
+constexpr float M2_GAME_OBJECT_MIN_RENDER_DISTANCE = 600.0f;
+
 // ---------------------------------------------------------------------------
 // M2 variation / idle animation timing (milliseconds)
 // ---------------------------------------------------------------------------

--- a/include/rendering/wmo_renderer.hpp
+++ b/include/rendering/wmo_renderer.hpp
@@ -78,6 +78,14 @@ public:
     bool isModelLoaded(uint32_t id) const;
 
     /**
+     * Check if a WMO instance is still live in the renderer. Owners that cache
+     * instance IDs use this to detect an instance dropped underneath them
+     * (e.g. by a renderer-wide clear) instead of addressing a dead handle.
+     * @param instanceId Instance identifier returned by createInstance
+     */
+    bool hasInstance(uint32_t instanceId) const;
+
+    /**
      * Unload WMO model and free GPU resources
      * @param id WMO model identifier
      */

--- a/src/core/entity_spawner_player.cpp
+++ b/src/core/entity_spawner_player.cpp
@@ -1026,6 +1026,30 @@ void EntitySpawner::spawnOnlineGameObject(uint64_t guid, uint32_t entry, uint32_
 
     auto goIt = gameObjectInstances_.find(guid);
     if (goIt != gameObjectInstances_.end()) {
+        // A tracked instance ID is only meaningful while the renderer still holds
+        // it. Renderer-wide clears (map change, device reset) drop instances
+        // without going through despawnGameObject(), which used to leave this map
+        // pointing at a dead handle — every later server CREATE for that GUID then
+        // took the position-update path below and the object stayed invisible for
+        // the rest of the session. Treat a dead handle as "not spawned".
+        bool instanceAlive = false;
+        if (renderer_) {
+            if (goIt->second.isWmo) {
+                auto* wr = renderer_->getWMORenderer();
+                instanceAlive = wr && wr->hasInstance(goIt->second.instanceId);
+            } else {
+                auto* mr = renderer_->getM2Renderer();
+                instanceAlive = mr && mr->hasInstance(goIt->second.instanceId);
+            }
+        }
+        if (!instanceAlive) {
+            LOG_WARNING("GO render instance vanished — respawning: guid=0x", std::hex, guid, std::dec,
+                        " displayId=", displayId, " instanceId=", goIt->second.instanceId);
+            gameObjectInstances_.erase(goIt);
+            goIt = gameObjectInstances_.end();
+        }
+    }
+    if (goIt != gameObjectInstances_.end()) {
         if (gameHandler_ && gameHandler_->isTransportGuid(guid)) {
             if (auto* transportManager = gameHandler_->getTransportManager()) {
                 if (transportManager->getTransport(guid)) {
@@ -1322,6 +1346,11 @@ void EntitySpawner::spawnOnlineGameObject(uint64_t guid, uint32_t entry, uint32_
                 return;
             }
 
+            // Keep game object models resident across the away-and-back cycle.
+            // Leaving town drops every instance of them, and the 60s reaper then
+            // evicted the model — the log showed PostBoxHuman.m2 (the mailbox)
+            // going through exactly that reap/reload churn on every return trip.
+            m2Renderer->setModelPinned(modelId, true);
             gameObjectDisplayIdModelCache_[displayId] = modelId;
         }
 
@@ -1331,6 +1360,12 @@ void EntitySpawner::spawnOnlineGameObject(uint64_t guid, uint32_t entry, uint32_
             LOG_WARNING("Failed to create gameobject instance for guid 0x", std::hex, guid, std::dec);
             return;
         }
+
+        // Server game objects are gameplay props, not scenery: exempt them from the
+        // adaptive doodad render distance, which drops to ~200 units in a city and
+        // was hiding mailboxes/chests well inside the range the server still
+        // considers them visible.
+        m2Renderer->setInstanceIsGameObject(instanceId, true);
 
         // Deeprun Tram cars: riding never used real mesh collision to begin with (Z is
         // fully code-locked to the transport's simulated position while boarded, not

--- a/src/rendering/m2_renderer.cpp
+++ b/src/rendering/m2_renderer.cpp
@@ -992,6 +992,7 @@ void M2Renderer::shutdown() {
         destroyModelGPU(model);
     }
     models.clear();
+    pinnedModelIds_.clear();
 
     // Destroy instance bone buffers
     for (auto& inst : instances) {

--- a/src/rendering/m2_renderer_instance.cpp
+++ b/src/rendering/m2_renderer_instance.cpp
@@ -265,6 +265,12 @@ void M2Renderer::removeInstance(uint32_t instanceId) {
     }
 }
 
+void M2Renderer::setInstanceIsGameObject(uint32_t instanceId, bool isGameObject) {
+    auto idxIt = instanceIndexById.find(instanceId);
+    if (idxIt == instanceIndexById.end() || idxIt->second >= instances.size()) return;
+    instances[idxIt->second].isGameObject = isGameObject;
+}
+
 void M2Renderer::setSkipCollision(uint32_t instanceId, bool skip) {
     for (auto& inst : instances) {
         if (inst.id == instanceId) {
@@ -379,10 +385,13 @@ void M2Renderer::clear() {
         }
     }
     models.clear();
+    pinnedModelIds_.clear();
     instances.clear();
     spatialGrid.clear();
     instanceIndexById.clear();
     instanceDedupMap_.clear();
+    for (auto& ids : cullSubmittedIds_) ids.clear();
+    for (auto& ids : cullReadableIds_) ids.clear();
     smokeParticles.clear();
     smokeInstanceIndices_.clear();
     portalInstanceIndices_.clear();
@@ -413,6 +422,8 @@ void M2Renderer::clearInstances() {
     spatialGrid.clear();
     instanceIndexById.clear();
     instanceDedupMap_.clear();
+    for (auto& ids : cullSubmittedIds_) ids.clear();
+    for (auto& ids : cullReadableIds_) ids.clear();
     smokeInstanceIndices_.clear();
     portalInstanceIndices_.clear();
     animatedInstanceIndices_.clear();
@@ -535,6 +546,15 @@ void M2Renderer::gatherCandidates(const glm::vec3& queryMin, const glm::vec3& qu
     }
 }
 
+void M2Renderer::setModelPinned(uint32_t modelId, bool pinned) {
+    if (pinned) {
+        pinnedModelIds_.insert(modelId);
+        modelUnusedSince_.erase(modelId);
+    } else {
+        pinnedModelIds_.erase(modelId);
+    }
+}
+
 void M2Renderer::cleanupUnusedModels() {
     // Build set of model IDs that are still referenced by instances
     std::unordered_set<uint32_t> usedModelIds;
@@ -551,8 +571,9 @@ void M2Renderer::cleanupUnusedModels() {
     // instance-free between despawn and respawn cycles.
     std::vector<uint32_t> toRemove;
     for (const auto& [id, model] : models) {
-        if (usedModelIds.find(id) != usedModelIds.end()) {
-            // Model still in use — clear any pending unused timestamp
+        if (usedModelIds.find(id) != usedModelIds.end() ||
+            pinnedModelIds_.find(id) != pinnedModelIds_.end()) {
+            // Model still in use or pinned — clear any pending unused timestamp
             modelUnusedSince_.erase(id);
             continue;
         }
@@ -611,6 +632,7 @@ void M2Renderer::unloadModel(uint32_t modelId) {
     destroyModelGPU(it->second);
     models.erase(it);
     modelUnusedSince_.erase(modelId);
+    pinnedModelIds_.erase(modelId);
     reapedModelIds_.push_back(modelId);
 }
 

--- a/src/rendering/m2_renderer_render.cpp
+++ b/src/rendering/m2_renderer_render.cpp
@@ -646,7 +646,13 @@ void M2Renderer::dispatchCullCompute(VkCommandBuffer cmd, uint32_t frameIndex, c
     smoothedRenderDist_ = glm::mix(smoothedRenderDist_, targetRenderDist, blendRate);
     const float maxRenderDistance = smoothedRenderDist_;
     const float maxRenderDistanceSq = maxRenderDistance * maxRenderDistance;
-    const float maxPossibleDistSq = maxRenderDistanceSq * 4.0f; // 2x safety margin
+    // The shader rejects on this bound before it ever reads the per-instance
+    // distance, so it has to clear the game-object floor as well — otherwise
+    // that floor is silently capped at 2x the ambient doodad distance.
+    const float maxPossibleDistSq = std::max(
+        maxRenderDistanceSq * 4.0f,  // 2x safety margin
+        rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE *
+        rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE);
 
     // --- Upload frustum planes + camera (UBO, binding 0) ---
     const glm::mat4 vp = camera.getProjectionMatrix() * camera.getViewMatrix();
@@ -710,6 +716,19 @@ void M2Renderer::dispatchCullCompute(VkCommandBuffer cmd, uint32_t frameIndex, c
         prevVP_ = vp;
     }
 
+    // Rotate this slot's ID log: the dispatch recorded below replaces the one
+    // whose results render() is about to consume, so the IDs it was built from
+    // become the readable set.  Done before the upload loop overwrites them, and
+    // after the early-out above, so "readable" always describes the last dispatch
+    // actually recorded on this slot.
+    if (frameIndex < 2) {
+        cullReadableIds_[frameIndex].swap(cullSubmittedIds_[frameIndex]);
+        cullSubmittedIds_[frameIndex].clear();
+        cullSubmittedIds_[frameIndex].reserve(numInstances);
+        for (uint32_t i = 0; i < numInstances; i++)
+            cullSubmittedIds_[frameIndex].push_back(instances[i].id);
+    }
+
     // --- Upload per-instance cull data (SSBO, binding 1) ---
     // The per-instance radius math used to be recomputed here every frame; it's
     // now precomputed once by recomputeCachedCullFactors() since it depends only
@@ -719,6 +738,11 @@ void M2Renderer::dispatchCullCompute(VkCommandBuffer cmd, uint32_t frameIndex, c
         for (uint32_t i = 0; i < numInstances; i++) {
             const auto& inst = instances[i];
             float effectiveMaxDistSq = maxRenderDistanceSq * inst.cachedEffectiveMaxDistSqFactor;
+            if (inst.isGameObject) {
+                effectiveMaxDistSq = std::max(effectiveMaxDistSq,
+                    rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE *
+                    rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE);
+            }
             if (inst.cachedIsSkyBird && inst.cachedHasAnimation && !inst.cachedDisableAnimation) {
                 constexpr float kBirdMaxDistSq =
                     rendering::M2_SKY_BIRD_MAX_RENDER_DISTANCE *
@@ -734,7 +758,9 @@ void M2Renderer::dispatchCullCompute(VkCommandBuffer cmd, uint32_t frameIndex, c
             // that were NOT rendered last frame (no reliable depth data).
             // Hysteresis: treat as "previously visible" unless culled for
             // 2+ consecutive frames, preventing single-frame false-cull flicker.
-            if (i < prevFrameVisible_.size() && prevFrameVisible_[i] < 2)
+            // The counter lives on the instance, so streaming churn can never
+            // pair it with a different object's history.
+            if (inst.hizPrevCulledFrames < 2)
                 flags |= 8u;
 
             input[i].sphere = glm::vec4(inst.cachedCullCenter, inst.cachedPaddedRadius);
@@ -823,27 +849,51 @@ void M2Renderer::render(VkCommandBuffer cmd, VkDescriptorSet perFrameSet, const 
     const uint32_t* visibility = static_cast<const uint32_t*>(cullOutputMapped_[frameIndex]);
     const bool gpuCullAvailable = (cullPipeline_ != VK_NULL_HANDLE && visibility != nullptr);
 
-    // Snapshot the GPU visibility results into prevFrameVisible_ so the NEXT
-    // frame's compute dispatch can set the per-instance `previouslyVisible`
-    // flag (bit 3).  We use a hysteresis counter instead of a binary flag to
-    // prevent a 1-frame-on / 1-frame-off oscillation: an object must be HiZ-
-    // culled for 2 consecutive frames before we stop considering it
-    // "previously visible".  This eliminates doodad flicker near characters
-    // caused by stale depth data from character movement.
+    // Scatter the GPU visibility results back onto the instances they were
+    // computed for.  The results belong to the dispatch recorded on this slot
+    // ~2 frames ago, so they are keyed by that dispatch's instance IDs, never by
+    // the current array index: createInstance() appends and removeInstance()
+    // swap-removes, so a respawned game object lands at the volatile tail of the
+    // array and would otherwise inherit the verdict of whatever transient object
+    // (spell visual, streamed doodad, creature) held that index two frames back
+    // — leaving it culled for as long as the churn continued.
+    //
+    // Instances with no entry in the readable set were created after that
+    // dispatch and keep their defaults: visible, and exempt from the HiZ test.
+    //
+    // hizPrevCulledFrames is a hysteresis counter rather than a binary flag: an
+    // object must be culled for 2 consecutive frames before it stops counting as
+    // "previously visible", which prevents the 1-frame-on / 1-frame-off
+    // oscillation that showed up as doodad flicker near moving characters.
     if (gpuCullAvailable) {
-        prevFrameVisible_.resize(numInstances, 0);
-        for (uint32_t i = 0; i < numInstances; ++i) {
-            if (visibility[i]) {
-                // Visible this frame — reset cull counter.
-                prevFrameVisible_[i] = 0;
+        const auto& ids = cullReadableIds_[frameIndex < 2 ? frameIndex : 0];
+        for (size_t k = 0; k < ids.size(); ++k) {
+            // Fast path: with no churn since that dispatch the ordering still
+            // matches, so skip the hash lookup.
+            M2Instance* inst = nullptr;
+            if (k < instances.size() && instances[k].id == ids[k]) {
+                inst = &instances[k];
             } else {
-                // Culled this frame — increment counter (cap at 3 to avoid overflow).
-                prevFrameVisible_[i] = std::min<uint8_t>(prevFrameVisible_[i] + 1, 3);
+                auto idxIt = instanceIndexById.find(ids[k]);
+                if (idxIt == instanceIndexById.end() || idxIt->second >= instances.size())
+                    continue;  // instance was removed since the dispatch
+                inst = &instances[idxIt->second];
+            }
+            if (visibility[k]) {
+                inst->lastCullVisible = 1;
+                inst->hizPrevCulledFrames = 0;
+            } else {
+                inst->lastCullVisible = 0;
+                inst->hizPrevCulledFrames =
+                    std::min<uint8_t>(inst->hizPrevCulledFrames + 1, 3);
             }
         }
     } else {
-        // No GPU cull data — conservatively mark all as visible (counter = 0).
-        prevFrameVisible_.assign(static_cast<size_t>(instances.size()), 0);
+        // No GPU cull data — conservatively treat everything as visible.
+        for (auto& inst : instances) {
+            inst.lastCullVisible = 1;
+            inst.hizPrevCulledFrames = 0;
+        }
     }
 
     // If GPU culling was not dispatched, fallback: compute distances on CPU
@@ -881,7 +931,12 @@ void M2Renderer::render(VkCommandBuffer cmd, VkDescriptorSet perFrameSet, const 
         const glm::mat4 vp = camera.getProjectionMatrix() * camera.getViewMatrix();
         frustum.extractFromMatrix(vp);
     }
-    const float maxPossibleDistSq = maxRenderDistanceSq * 4.0f;
+    // Matches the bound uploaded to the cull shader, including the headroom the
+    // game-object floor needs (see dispatchCullCompute).
+    const float maxPossibleDistSq = std::max(
+        maxRenderDistanceSq * 4.0f,
+        rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE *
+        rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE);
 
     const uint32_t totalInstances = static_cast<uint32_t>(instances.size());
     struct VisibleChunk {
@@ -906,22 +961,37 @@ void M2Renderer::render(VkCommandBuffer cmd, VkDescriptorSet perFrameSet, const 
             float distSq;
             float effectiveMaxDistSq;
 
+            // Server game objects keep a distance floor instead of following the
+            // ambient doodad distance down; it also feeds the fade curve below,
+            // so a mailbox doesn't fade out at the doodad boundary either.
+            const float instanceMaxDistSq = [&] {
+                float d = maxRenderDistanceSq * instance.cachedEffectiveMaxDistSqFactor;
+                if (instance.isGameObject) {
+                    d = std::max(d, rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE *
+                                    rendering::M2_GAME_OBJECT_MIN_RENDER_DISTANCE);
+                }
+                return d;
+            }();
+
             if (forceNoCull_) {
                 if (!instance.cachedIsValid) continue;
                 glm::vec3 toCam = instance.position - camPos;
                 distSq = glm::dot(toCam, toCam);
-                effectiveMaxDistSq = maxRenderDistanceSq * instance.cachedEffectiveMaxDistSqFactor;
+                effectiveMaxDistSq = instanceMaxDistSq;
             } else if (gpuCullAvailable && i < numInstances) {
-                if (!visibility[i]) continue;
+                // Per-instance verdict scattered above — indexing visibility[]
+                // directly here would read the slot of whichever instance held
+                // this array position when the dispatch was recorded.
+                if (!instance.lastCullVisible) continue;
                 glm::vec3 toCam = instance.position - camPos;
                 distSq = glm::dot(toCam, toCam);
-                effectiveMaxDistSq = maxRenderDistanceSq * instance.cachedEffectiveMaxDistSqFactor;
+                effectiveMaxDistSq = instanceMaxDistSq;
             } else {
                 if (!instance.cachedIsValid || instance.cachedIsSmoke || instance.cachedIsInvisibleTrap) continue;
                 glm::vec3 toCam = instance.position - camPos;
                 distSq = glm::dot(toCam, toCam);
                 if (distSq > maxPossibleDistSq) continue;
-                effectiveMaxDistSq = maxRenderDistanceSq * instance.cachedEffectiveMaxDistSqFactor;
+                effectiveMaxDistSq = instanceMaxDistSq;
                 if (distSq > effectiveMaxDistSq) continue;
                 float paddedRadius = instance.cachedPaddedRadius;
                 if (paddedRadius > 0.0f && !frustum.intersectsSphere(instance.cachedCullCenter, paddedRadius)) continue;

--- a/src/rendering/wmo_renderer.cpp
+++ b/src/rendering/wmo_renderer.cpp
@@ -1074,6 +1074,12 @@ const std::vector<WMORenderer::DoodadTemplate>* WMORenderer::getDoodadTemplates(
     return nullptr;
 }
 
+bool WMORenderer::hasInstance(uint32_t instanceId) const {
+    return std::find_if(instances.begin(), instances.end(),
+                        [instanceId](const WMOInstance& inst) { return inst.id == instanceId; })
+           != instances.end();
+}
+
 void WMORenderer::removeInstance(uint32_t instanceId) {
     auto it = std::find_if(instances.begin(), instances.end(),
                           [instanceId](const WMOInstance& inst) { return inst.id == instanceId; });


### PR DESCRIPTION
Pin game object M2 models so the 60s unused-model reaper can't evict them while the player is away, exempt game objects from the adaptive doodad render distance that collapses to ~200 units in a city, and key GPU cull results by instance ID so a respawned object can't inherit the verdict of whatever instance held its array slot two frames earlier.