### PR TITLE
fix(tests): link glm into test_chat_types

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,6 +166,15 @@ add_executable(test_chat_types test_chat_types.cpp)
 target_include_directories(test_chat_types PRIVATE ${TEST_INCLUDE_DIRS})
 target_include_directories(test_chat_types SYSTEM PRIVATE ${TEST_SYSTEM_INCLUDE_DIRS})
 target_link_libraries(test_chat_types PRIVATE catch2_main)
+# world_packets.hpp reaches entity.hpp, which includes math/spline.hpp and so
+# <glm/glm.hpp>. glm arrives with the imported target, not with any directory
+# listed above, so without this the target only builds where glm happens to sit
+# in a default system include path.
+if(TARGET glm::glm-header-only)
+    target_link_libraries(test_chat_types PRIVATE glm::glm-header-only)
+elseif(TARGET glm::glm)
+    target_link_libraries(test_chat_types PRIVATE glm::glm)
+endif()
 add_test(NAME chat_types COMMAND test_chat_types)
 register_test_target(test_chat_types)
 # ── test_equipment_set_packets ───────────────────────────────


### PR DESCRIPTION
## What

Adds the glm link block to the `test_chat_types` target in `tests/CMakeLists.txt`, matching the pattern already used by `test_hill_climbing`, `test_spline`, `test_transport_path_repo`, and `test_taxi_packets`.

```cmake
if(TARGET glm::glm-header-only)
    target_link_libraries(test_chat_types PRIVATE glm::glm-header-only)
elseif(TARGET glm::glm)
    target_link_libraries(test_chat_types PRIVATE glm::glm)
endif()
```

## Why

`test_chat_types` does not build on macOS. It fails at the preprocessor:

```
In file included from tests/test_chat_types.cpp:3:
In file included from include/game/world_packets.hpp:6:
In file included from include/game/entity.hpp:16:
include/math/spline.hpp:5:10: fatal error: 'glm/glm.hpp' file not found
    5 | #include <glm/glm.hpp>
      |          ^~~~~~~~~~~~~
1 error generated.
```

The include chain is `test_chat_types.cpp` to `game/world_packets.hpp` to `game/entity.hpp:16` to `math/spline.hpp:5` to `<glm/glm.hpp>`. The target linked only `catch2_main`, so it never received glm's include path.

glm is not vendored in `extern/`. It comes from `find_package(glm)`, and its include directory arrives with the imported target rather than through `TEST_INCLUDE_DIRS` or `TEST_SYSTEM_INCLUDE_DIRS`. The comment above `test_hill_climbing` at `tests/CMakeLists.txt:50` already records this, from the previous time it bit:

> glm is not vendored, it comes from find_package(glm), and its include path arrives with the imported target rather than through any directory this file lists.

`test_taxi_packets`, added in the same commit as `test_chat_types` (3ed9330d), already carries the block. `test_chat_types` was the one that missed it.

## Why CI did not catch it

`.github/workflows/build.yml` runs on `ubuntu-24.04` and `ubuntu-24.04-arm` only. There, `libglm-dev` installs the headers into `/usr/include`, which the compiler searches by default, so the missing link target makes no difference and the build is green. macOS puts glm under the Homebrew prefix, which is not on the default search path, so it is the only platform that reports the error. macOS appears in `release.yml` (`macos-15`), which runs on release rather than on pull requests.

This is a build-configuration bug with a platform-dependent symptom, not a behaviour change. The compiled test itself is untouched.

## Scope

I audited the rest of the test suite rather than fixing only the reported failure. Running each target's exact compile line from `compile_commands.json` with `-fsyntax-only`: of 55 test translation units, 27 build without glm's include path, and all 27 are clean. None of them reach `entity.hpp`, so `test_chat_types` was the only affected target.

The three other targets added recently (`test_equipment_set_packets`, `test_achievement_criteria`, `test_packed_time`) include only `network/packet.hpp`, `game/achievement_criteria.hpp`, and `game/packed_time.hpp` respectively, and are correct as they stand. I left them alone rather than adding a block they do not currently need.

## Effect on Linux

None. On Linux, `glm::glm` (or `glm::glm-header-only`) resolves to the same headers already found via `/usr/include`, and the `if(TARGET ...)` guard makes the block a no-op where neither imported target exists.

## Verification

`cmake --build build --parallel 12` exits 0 on macOS 15 (arm64, Homebrew glm 1.0), and `ctest` reports 55 of 55 tests passing, including `chat_types`.

## Possible follow-up, not included here

Adding a `macos-15` job to the `build.yml` matrix would let CI catch this class of error on pull requests instead of at release time or on a contributor's machine. That is a separate change and I have kept it out of this PR.
