### PR TITLE
Add Linux StormLib linker flags to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ For Windows/MSYS2, Visual Studio, and platform-specific notes, see the
 git clone --recurse-submodules https://github.com/Kelsidavis/WoWee.git
 cd WoWee
 
-cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+LDFLAGS="-lstorm -lz -lbz2" cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel
 ```
 


### PR DESCRIPTION
"-lstorm -lz -lbz2" flags must be
included when compiling on Linux for StormLib to work correctly with the extract_assets.sh script.
Tested of Arch Linux and could not extract assets until I compile with CMake using these flags above.