### PR TITLE
Fix: arrow keys don't move the character

### DIFF
--- a/src/rendering/camera_controller.cpp
+++ b/src/rendering/camera_controller.cpp
@@ -2254,10 +2254,12 @@ void CameraController::update(float deltaTime) {
     bool movementSuppressed = movementSuppressTimer_ > 0.0f;
 
     // Determine current key states
-    bool keyW = !uiWantsKeyboard && !sitting && !movementSuppressed && input.isKeyPressed(SDL_SCANCODE_W);
-    bool keyS = !uiWantsKeyboard && !sitting && !movementSuppressed && input.isKeyPressed(SDL_SCANCODE_S);
-    bool keyA = !uiWantsKeyboard && !sitting && !movementSuppressed && input.isKeyPressed(SDL_SCANCODE_A);
-    bool keyD = !uiWantsKeyboard && !sitting && !movementSuppressed && input.isKeyPressed(SDL_SCANCODE_D);
+    // Arrow keys mirror WASD the way the original client maps them:
+    // Up/Down move, Left/Right turn (strafe stays on Q/E).
+    bool keyW = !uiWantsKeyboard && !sitting && !movementSuppressed && (input.isKeyPressed(SDL_SCANCODE_W) || input.isKeyPressed(SDL_SCANCODE_UP));
+    bool keyS = !uiWantsKeyboard && !sitting && !movementSuppressed && (input.isKeyPressed(SDL_SCANCODE_S) || input.isKeyPressed(SDL_SCANCODE_DOWN));
+    bool keyA = !uiWantsKeyboard && !sitting && !movementSuppressed && (input.isKeyPressed(SDL_SCANCODE_A) || input.isKeyPressed(SDL_SCANCODE_LEFT));
+    bool keyD = !uiWantsKeyboard && !sitting && !movementSuppressed && (input.isKeyPressed(SDL_SCANCODE_D) || input.isKeyPressed(SDL_SCANCODE_RIGHT));
     bool keyQ = !uiWantsKeyboard && !sitting && !movementSuppressed && input.isKeyPressed(SDL_SCANCODE_Q);
     bool keyE = !uiWantsKeyboard && !sitting && !movementSuppressed && input.isKeyPressed(SDL_SCANCODE_E);
     bool shiftDown = !uiWantsKeyboard && (input.isKeyPressed(SDL_SCANCODE_LSHIFT) || input.isKeyPressed(SDL_SCANCODE_RSHIFT));
@@ -2527,6 +2529,8 @@ void CameraController::update(float deltaTime) {
             input.isKeyPressed(SDL_SCANCODE_W) || input.isKeyPressed(SDL_SCANCODE_S) ||
             input.isKeyPressed(SDL_SCANCODE_A) || input.isKeyPressed(SDL_SCANCODE_D) ||
             input.isKeyPressed(SDL_SCANCODE_Q) || input.isKeyPressed(SDL_SCANCODE_E) ||
+            input.isKeyPressed(SDL_SCANCODE_UP) || input.isKeyPressed(SDL_SCANCODE_DOWN) ||
+            input.isKeyPressed(SDL_SCANCODE_LEFT) || input.isKeyPressed(SDL_SCANCODE_RIGHT) ||
             input.isKeyPressed(SDL_SCANCODE_SPACE));
         // Not gated on uiWantsKeyboard, which is a different question, and not
         // on the interface wanting the mouse either: both flags are already


### PR DESCRIPTION
## Problem

The arrow keys do nothing in game, even though the keybinding catalog (`src/pipeline/wowee_keybindings.cpp`) declares `UP`/`DOWN` as alternate bindings for `MOVE_FORWARD`/`MOVE_BACKWARD` and `LEFT`/`RIGHT` for `TURN_LEFT`/`TURN_RIGHT`. Movement polling in `src/rendering/camera_controller.cpp` reads hardcoded WASD/QE scancodes and never looks at the arrows.

## Fix

Map the arrows the way the original client does, at the two polling sites in `camera_controller.cpp`:

- **Up/Down** mirror W/S (move forward/backward)
- **Left/Right** mirror A/D (turn in third person without RMB, strafe with RMB held — strafe stays on Q/E)
- Arrows added to the `anyMoveKey` set so pressing one stands a sitting character up, like every other movement key

No behavior change for WASD/QE/Space.

## Testing

Built and tested on macOS ARM64 (Apple Silicon M5, MoltenVK) against an AzerothCore WotLK 3.3.5a server: arrows move and turn as expected in third person, with and without RMB held; WASD/QE unchanged; a sitting character stands up on arrow press.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012vqjncMncrXUEDFvP23Hzh