### PR TITLE
fix(auth): keep the SRP session key out of the logs

### DIFF
--- a/src/game/game_handler.cpp
+++ b/src/game/game_handler.cpp
@@ -141,9 +141,12 @@ bool GameHandler::connect(const std::string& host,
     this->build = build;
     this->realmId_ = realmId;
 
-    // Diagnostic: dump session key for AUTH_REJECT debugging
-    LOG_INFO("GameHandler session key (", sessionKey.size(), "): ",
-             core::toHexString(sessionKey.data(), sessionKey.size()));
+    // The session key is the shared secret the world handshake proves knowledge
+    // of and the header cipher is keyed from: anyone holding these 40 bytes can
+    // authenticate as this account and decrypt its traffic. It must never reach
+    // a log, which is a file users are routinely asked to attach to a bug
+    // report. Its length is the only part of it that diagnoses anything.
+    LOG_INFO("GameHandler session key received (", sessionKey.size(), " bytes)");
     // Generate random client seed
     this->clientSeed = generateClientSeed();
     LOG_DEBUG("Generated client seed: 0x", std::hex, clientSeed, std::dec);

--- a/src/game/world_packets.cpp
+++ b/src/game/world_packets.cpp
@@ -283,11 +283,15 @@ std::vector<uint8_t> AuthSessionPacket::computeAuthHash(
     // Session key (40 bytes)
     hashInput.insert(hashInput.end(), sessionKey.begin(), sessionKey.end());
 
-    // Diagnostic: dump auth hash inputs for debugging AUTH_REJECT
+    // Everything an AUTH_REJECT needs, and nothing that authenticates. The
+    // session key is a credential (see GameHandler::onAuthSuccess) and
+    // hashInput ends with all 40 of its bytes, so neither can be logged even at
+    // DEBUG - a debug log is still a file that gets attached to bug reports.
+    // The digest is what goes out on the wire, so it is safe and is the value
+    // actually worth comparing against the server's.
     LOG_DEBUG("AUTH HASH: account='", accountName, "' clientSeed=0x", std::hex, clientSeed,
-              " serverSeed=0x", serverSeed, std::dec);
-    LOG_DEBUG("AUTH HASH: sessionKey=", core::toHexString(sessionKey.data(), sessionKey.size()));
-    LOG_DEBUG("AUTH HASH: input(", hashInput.size(), ")=", core::toHexString(hashInput.data(), hashInput.size()));
+              " serverSeed=0x", serverSeed, std::dec, " sessionKey=", sessionKey.size(),
+              " bytes input=", hashInput.size(), " bytes");
 
     // Compute SHA1 hash
     auto result = auth::Crypto::sha1(hashInput);


### PR DESCRIPTION
## Summary

`GameHandler::connect()` writes all 40 bytes of the SRP session key to the log at INFO on every world login, and `AuthSessionPacket::computeAuthHash()` writes them again at DEBUG along with the full hash input, which ends with the same 40 bytes.

That key is the shared secret the world handshake proves knowledge of, and the header cipher is keyed from it. Anyone holding those bytes can authenticate as the account and decrypt its traffic. The log is the file users are routinely asked to attach to a bug report.

## Fix

Log the key's length instead of its contents at both sites.

The DEBUG line in `computeAuthHash` keeps everything an AUTH_REJECT diagnosis actually needs — account name, client seed, server seed, and the sizes of the key and the hash input — and drops the key and the input themselves. The resulting SHA1 digest is what goes out on the wire, so it is safe and is the value actually worth comparing against the server's.

## Test plan

- [x] Builds clean from `master`.
- [x] Live login against a 3.3.5a realm: the log now reads `GameHandler session key received (40 bytes)` with no hex.
- [x] Grepped a full session log for the key's hex; no occurrences.
