### PR TITLE
fix(vendor): sell the whole stack, not one item of it

### DIFF
--- a/include/game/sell_count.hpp
+++ b/include/game/sell_count.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <cstdint>
+
+namespace wowee::game {
+
+/// How many of a stack a vendor sell should ask for.
+///
+/// One, which is what all four sell sites hardcoded, sells a single unit of a
+/// twenty-stack and leaves nineteen behind - twice over, because the auto-sell
+/// sweep also charged one unit's price into the total it reports and never
+/// revisited the slot. Right-clicking an item at a vendor in 3.3.5 sells the
+/// whole stack, CMSG_SELL_ITEM carries the count, and the server clamps it to
+/// what is actually there.
+///
+/// A slot that has not said how many it holds still holds one.
+[[nodiscard]] inline uint32_t sellCountForStack(uint32_t stackCount) {
+    return stackCount > 0 ? stackCount : 1u;
+}
+
+}  // namespace wowee::game

--- a/src/game/inventory_handler.cpp
+++ b/src/game/inventory_handler.cpp
@@ -15,6 +15,7 @@
 #include "audio/player_voice_manager.hpp"
 #include "core/application.hpp"
 #include "core/logger.hpp"
+#include "game/sell_count.hpp"
 #include "network/world_socket.hpp"
 #include "network/packet.hpp"
 #include "pipeline/asset_manager.hpp"
@@ -1488,13 +1489,14 @@ void InventoryHandler::sellItemBySlot(int backpackIndex) {
               " itemGuid=0x", std::hex, itemGuid, std::dec,
               " vendorGuid=0x", std::hex, currentVendorItems_.vendorGuid, std::dec);
     if (itemGuid != 0 && currentVendorItems_.vendorGuid != 0) {
+        const uint32_t count = sellCountForStack(slot.item.stackCount);
         BuybackItem sold;
         sold.itemGuid = itemGuid;
         sold.item = slot.item;
-        sold.count = 1;
+        sold.count = count;
         pendingSellToBuyback_[itemGuid] = sold;
         buybackItems_.push_back(sold);
-        sellItem(currentVendorItems_.vendorGuid, itemGuid, 1);
+        sellItem(currentVendorItems_.vendorGuid, itemGuid, count);
     } else if (itemGuid == 0) {
         owner_.raiseUiError("Cannot sell: item not found in inventory.");
         LOG_WARNING("Sell failed: missing item GUID for slot ", backpackIndex);
@@ -1533,13 +1535,14 @@ void InventoryHandler::sellItemInBag(int bagIndex, int slotIndex) {
     }
 
     if (itemGuid != 0 && currentVendorItems_.vendorGuid != 0) {
+        const uint32_t count = sellCountForStack(slot.item.stackCount);
         BuybackItem sold;
         sold.itemGuid = itemGuid;
         sold.item = slot.item;
-        sold.count = 1;
+        sold.count = count;
         pendingSellToBuyback_[itemGuid] = sold;
         buybackItems_.push_back(sold);
-        sellItem(currentVendorItems_.vendorGuid, itemGuid, 1);
+        sellItem(currentVendorItems_.vendorGuid, itemGuid, count);
     } else if (itemGuid == 0) {
         owner_.raiseUiError("Cannot sell: item not found.");
     } else {
@@ -2502,8 +2505,10 @@ void InventoryHandler::handleListInventory(network::Packet& packet) {
                 uint64_t itemGuid = owner_.backpackSlotGuidsRef()[i];
                 if (itemGuid == 0) itemGuid = owner_.resolveOnlineItemGuid(slot.item.itemId);
                 if (itemGuid != 0) {
-                    sellItem(currentVendorItems_.vendorGuid, itemGuid, 1);
-                    totalSellPrice += sellPrice;
+                    const uint32_t count = sellCountForStack(slot.item.stackCount);
+                    sellItem(currentVendorItems_.vendorGuid, itemGuid, count);
+                    // Per unit, so the money reported matches the money paid.
+                    totalSellPrice += sellPrice * count;
                     ++itemsSold;
                 }
             }
@@ -2529,8 +2534,9 @@ void InventoryHandler::handleListInventory(network::Packet& packet) {
                     }
                     if (itemGuid == 0) itemGuid = owner_.resolveOnlineItemGuid(slot.item.itemId);
                     if (itemGuid != 0) {
-                        sellItem(currentVendorItems_.vendorGuid, itemGuid, 1);
-                        totalSellPrice += sellPrice;
+                        const uint32_t count = sellCountForStack(slot.item.stackCount);
+                        sellItem(currentVendorItems_.vendorGuid, itemGuid, count);
+                        totalSellPrice += sellPrice * count;
                         ++itemsSold;
                     }
                 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -163,6 +163,10 @@ endfunction()
 
 
 
+# What a vendor sell asks for. Header-only arithmetic, no game state.
+wowee_add_test(test_sell_count
+    SOURCES test_sell_count.cpp)
+
 # Stock-style hill climbing regression test. Run directly with:
 #   cmake --build build --target test_hill_climbing && ctest --test-dir build -R hill_climbing
 wowee_add_test(test_hill_climbing

--- a/tests/test_sell_count.cpp
+++ b/tests/test_sell_count.cpp
@@ -1,0 +1,20 @@
+#include <catch_amalgamated.hpp>
+
+#include "game/sell_count.hpp"
+
+using wowee::game::sellCountForStack;
+
+// All four vendor sell sites asked for exactly one unit while the slot's own
+// stack count was in hand, so selling a stack of twenty sold one and left
+// nineteen - and the auto-sell sweep charged one unit's price into the total it
+// reported and never came back to the slot. 3.3.5 sells the whole stack on a
+// right-click, CMSG_SELL_ITEM carries the count, and the server clamps it.
+TEST_CASE("a vendor sell asks for the whole stack", "[vendor][inventory]") {
+    CHECK(sellCountForStack(20) == 20u);
+    CHECK(sellCountForStack(5) == 5u);
+    CHECK(sellCountForStack(1) == 1u);
+
+    // A slot that never said how many it holds still holds one - answering
+    // zero would sell nothing at all, which is worse than selling one.
+    CHECK(sellCountForStack(0) == 1u);
+}


### PR DESCRIPTION
## Summary

All four vendor sell sites ask `CMSG_SELL_ITEM` for a count of one while the slot's own `stackCount` is in hand, so selling a stack of twenty sells one and leaves nineteen behind. In 3.3.5 a right-click at a vendor sells the whole stack, the opcode carries the count, and the server clamps it to what is actually there.

The auto-sell-greys sweep is wrong twice over: it sells one item per slot and never revisits the slot, and it adds one unit's price to the total it reports — so the "sold N items for X" line understates what was paid.

## Fix

A named `sellCountForStack` helper at all four sites, so the "a slot that never said how many it holds still holds one" case is stated once rather than four times, and can be tested without game state. Buyback rows record the real count, and the auto-sell total multiplies the unit price by it.

## Test plan

- [x] Builds clean from `master`; `test_sell_count` passes.
- [x] Vendor: right-clicked a stack of 20 greys — all 20 sold, and the money matches the stack's value.
- [x] Buyback list shows the full stack rather than a single item.
