### PR TITLE
fix(spawner): drop part-uploaded buildings when the map changes

### DIFF
--- a/src/core/entity_spawner.cpp
+++ b/src/core/entity_spawner.cpp
@@ -330,6 +330,14 @@ void EntitySpawner::clearAllQueues() {
     pendingOnlinePlayerEquipment_.clear();
     deferredEquipmentQueue_.clear();
     pendingGameObjectSpawns_.clear();
+    // Including the one that is already partway onto the GPU. An incremental
+    // upload survives a map change otherwise: processPendingWmoUploads() only
+    // gives up when the renderer pointer is null, and a transition leaves the
+    // WMORenderer alive with its contents cleared. The upload then finishes
+    // against a renderer that no longer knows the model, calls finishWmoSpawn()
+    // on the new map, and puts the old map's building - or a transport, which
+    // then registers itself here - into a world it does not belong to.
+    pendingWmoUploads_.clear();
     pendingTransportRegistrations_.clear();
     pendingTransportMoves_.clear();
     pendingTransportDoodadBatches_.clear();


### PR DESCRIPTION
## Summary

`EntitySpawner::clearAllQueues()` lists twenty-one containers and not
`pendingWmoUploads_`.

## Fix

`processPendingWmoUploads()` only gives up when the renderer pointer is null,
and a map transition leaves the `WMORenderer` alive with its contents cleared —
so a part-uploaded building carries on against a renderer that no longer knows
its model, and calls `finishWmoSpawn()` on the new map. A transport doing that
registers itself against the world it is not in.

One line, next to the queues it belongs with.

## Test plan

- [x] Compiles clean against master
- [x] Read against `processPendingWmoUploads()` and the map-transition path in
      `world_loader.cpp`, which clears the renderer but not this queue
- [ ] Not observed in play — found by reading the clear list against the
      members it is meant to cover
