### PR TITLE
fix(vulkan): do not present a frame whose submission failed

### DIFF
--- a/src/rendering/vk_context.cpp
+++ b/src/rendering/vk_context.cpp
@@ -2659,6 +2659,20 @@ void VkContext::endFrame(VkCommandBuffer cmd, uint32_t imageIndex) {
         if (submitResult == VK_ERROR_DEVICE_LOST) {
             deviceLost_ = true;
         }
+        // And no present. renderSem is signalled by the submission that just
+        // failed, so presenting on it queues a wait that nothing will ever
+        // satisfy - the same trap the timeline value above is withheld to
+        // avoid, one semaphore further along. A driver answers that with a
+        // hang or a second error, either of which buries the real one.
+        //
+        // Rebuild instead: recreateSwapchain() waits the device idle and
+        // remakes every semaphore unsignalled, which is the only way back from
+        // here that does not carry the broken sync state forward. The frame
+        // slot still advances so the next beginFrame does not wait on this
+        // one's unsignalled timeline value.
+        swapchainDirty = true;
+        currentFrame = (currentFrame + 1) % MAX_FRAMES_IN_FLIGHT;
+        return;
     }
 
     VkPresentInfoKHR presentInfo{};


### PR DESCRIPTION
## Summary

`VkContext::endFrame()` logs a failed `vkQueueSubmit`, sets `deviceLost_` where
that applies, and then calls `vkQueuePresentKHR` waiting on `renderSem` — the
semaphore the failed submission was supposed to signal.

## Fix

The code directly above is already careful about this trap one semaphore further
along: it withholds `frame.timelineValue` on failure so the next `beginFrame`
does not wait on a value that will never arrive. The present path never got the
same treatment, so a device loss or an allocation failure becomes a hang or a
second error stacked on the first — and the second is the one that gets
reported.

It now returns without presenting, and marks the swapchain dirty:
`recreateSwapchain()` waits the device idle and remakes every semaphore
unsignalled, which is the only way back from here that does not carry the broken
sync state forward. The frame slot still advances, so the next `beginFrame` does
not wait on this frame's unsignalled timeline value.

## Test plan

- [x] Compiles clean against master
- [x] Checked against the semaphore lifecycle in `recreateSwapchain()`, which
      destroys and remakes each one unsignalled after `vkDeviceWaitIdle`
- [ ] Not exercised: this is an error path, and reaching it needs submit
      failure injection. The change is reasoned from the code, not observed —
      worth your eye on the recovery choice in particular
